### PR TITLE
Added AesPasswordEncryptedPubSub

### DIFF
--- a/OwlCore.Kubo.sln
+++ b/OwlCore.Kubo.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.32802.463
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OwlCore.Kubo", "src\OwlCore.Kubo.csproj", "{595227CB-8079-47C1-B613-09B2095E11F9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OwlCore.Kubo.Tests", "tests\OwlCore.Kubo.Tests\OwlCore.Kubo.Tests.csproj", "{011C9F52-C41E-4799-83F2-E099FE142516}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OwlCore.Kubo.Tests", "tests\OwlCore.Kubo.Tests\OwlCore.Kubo.Tests.csproj", "{011C9F52-C41E-4799-83F2-E099FE142516}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AesPasswordEncryptedPubSub.cs
+++ b/src/AesPasswordEncryptedPubSub.cs
@@ -1,0 +1,110 @@
+﻿using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.ComponentModel;
+using OwlCore.Extensions;
+using System.Security.Cryptography;
+using System.Text;
+using PublishedMessage = OwlCore.Kubo.Models.PublishedMessage;
+
+namespace OwlCore.Kubo;
+
+/// <summary>
+/// Encrypts outgoing and decrypts incoming pubsub messages using AES encryption derived from a pre-shared passkey.
+/// </summary>
+public class AesPasswordEncryptedPubSub : IPubSubApi, IDelegatable<IPubSubApi>
+{
+    private readonly string _password;
+    private readonly string? _salt;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="AesPasswordEncryptedPubSub"/>.
+    /// </summary>
+    /// <param name="inner">An existing, functional <see cref="IPubSubApi"/> instance to use for sending and receiving encrypted messages.</param>
+    /// <param name="password">A pre-shared passkey used for encryption and decryption.</param>
+    /// <param name="salt">An optional password salt.</param>
+    public AesPasswordEncryptedPubSub(IPubSubApi inner, string password, string? salt = null)
+    {
+        Inner = inner;
+        _password = password;
+        _salt = salt;
+    }
+
+    /// <inheritdoc />
+    public IPubSubApi Inner { get; }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<Peer>> PeersAsync(string? topic = null, CancellationToken cancel = default) => Inner.PeersAsync(topic, cancel);
+
+    /// <inheritdoc />
+    public Task PublishAsync(string topic, string message, CancellationToken cancel = default) => PublishAsync(topic, Encoding.UTF8.GetBytes(message), cancel);
+
+    /// <inheritdoc />
+    public Task PublishAsync(string topic, byte[] message, CancellationToken cancel = default) => PublishAsync(topic, new MemoryStream(message), cancel);
+
+    /// <inheritdoc />
+    public async Task PublishAsync(string topic, Stream message, CancellationToken cancel = default)
+    {
+        if (message.CanSeek)
+            message.Seek(0, SeekOrigin.Begin);
+
+        var aes = Aes.Create();
+        var passBytes = new Rfc2898DeriveBytes(password: _password, salt: Encoding.UTF8.GetBytes(_salt ?? string.Empty));
+
+        aes.Key = passBytes.GetBytes(aes.KeySize / 8);
+        aes.IV = passBytes.GetBytes(aes.BlockSize / 8);
+
+        using var encryptedOutputStream = new MemoryStream();
+        using var streamEncryptor = new CryptoStream(encryptedOutputStream, aes.CreateEncryptor(), CryptoStreamMode.Write);
+
+        var unencryptedBytes = await message.ToBytesAsync();
+        streamEncryptor.Write(unencryptedBytes, 0, unencryptedBytes.Length);
+        streamEncryptor.FlushFinalBlock();
+
+        encryptedOutputStream.Position = 0;
+
+        await Inner.PublishAsync(topic, encryptedOutputStream, cancel);
+    }
+
+    /// <inheritdoc />
+    public Task SubscribeAsync(string topic, Action<IPublishedMessage> handler, CancellationToken cancellationToken)
+    {
+        return Inner.SubscribeAsync(topic, msg =>
+        {
+            if (TryTransformPublishedMessage(msg) is IPublishedMessage transformedMsg)
+            {
+                handler(transformedMsg);
+            }
+        }, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<string>> SubscribedTopicsAsync(CancellationToken cancel = default)
+    {
+        return Inner.SubscribedTopicsAsync(cancel);
+    }
+
+    internal IPublishedMessage? TryTransformPublishedMessage(IPublishedMessage publishedMessage)
+    {
+        var aes = Aes.Create();
+        var passBytes = new Rfc2898DeriveBytes(password: _password, salt: Encoding.UTF8.GetBytes(_salt ?? string.Empty));
+
+        aes.Key = passBytes.GetBytes(aes.KeySize / 8);
+        aes.IV = passBytes.GetBytes(aes.BlockSize / 8);
+
+        try
+        {
+            using var outputStream = new MemoryStream();
+            using var streamDecryptor = new CryptoStream(publishedMessage.DataStream, aes.CreateDecryptor(), CryptoStreamMode.Read);
+            streamDecryptor.CopyTo(outputStream);
+
+            var outputBytes = outputStream.ToBytes();
+
+            return new PublishedMessage(publishedMessage.Sender, publishedMessage.Topics, publishedMessage.SequenceNumber, outputBytes, outputStream, publishedMessage.Id, publishedMessage.Size);
+        }
+        catch
+        {
+            // If the message can't be decrypted, swallow and ignore it. Unencrypted messages can be read via the normal, unencrypted pubsub API.
+            return null;
+        }
+    }
+}

--- a/src/Models/PublishedMessage.cs
+++ b/src/Models/PublishedMessage.cs
@@ -1,0 +1,44 @@
+﻿using Ipfs;
+
+namespace OwlCore.Kubo.Models;
+
+/// <summary>
+/// A implementation of <see cref="IPublishedMessage"/> where each property can be a custom value.
+/// </summary>
+public class PublishedMessage : IPublishedMessage
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="PublishedMessage"/>.
+    /// </summary>
+    public PublishedMessage(Peer sender, IEnumerable<string> topics, byte[] sequenceNumber, byte[] dataBytes, Stream dataStream, Cid id, long size)
+    {
+        Sender = sender;
+        Topics = topics;
+        SequenceNumber = sequenceNumber;
+        DataBytes = dataBytes;
+        DataStream = dataStream;
+        Id = id;
+        Size = size;
+    }
+
+    /// <inheritdoc/>
+    public Peer Sender { get; }
+
+    /// <inheritdoc/>
+    public IEnumerable<string> Topics { get; }
+
+    /// <inheritdoc/>
+    public byte[] SequenceNumber { get; }
+
+    /// <inheritdoc/>
+    public byte[] DataBytes { get; }
+
+    /// <inheritdoc/>
+    public Stream DataStream { get; }
+
+    /// <inheritdoc/>
+    public Cid Id { get; }
+
+    /// <inheritdoc/>
+    public long Size { get; }
+}

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -14,13 +14,17 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.5.1</Version>
+    <Version>0.6.0</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
+--- 0.6.0 ---
+[New]
+Added AesPasswordEncryptedPubSub. Wrap around an instance of IPubSubApi and automatically encrypt/decrypt messages using a pre-shared passkey.
+
 --- 0.5.1 ---
 [Fixed]
 Fixed an issue where Disposing an MfsStream would not flush the data, resulting in errors when a separate MfsStream to the same resource was opened.
@@ -126,7 +130,7 @@ Added unit tests.
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.0.0" />
-    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.0.3" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.0.4" />
     <PackageReference Include="OwlCore" Version="0.1.0" />
     <PackageReference Include="OwlCore.Storage" Version="0.5.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />

--- a/tests/OwlCore.Kubo.Tests/AesPasswordEncryptedPubSubTests.cs
+++ b/tests/OwlCore.Kubo.Tests/AesPasswordEncryptedPubSubTests.cs
@@ -9,27 +9,8 @@
             await KuboAccess.TryInitAsync();
 
             var encryptedPubsub = new AesPasswordEncryptedPubSub(KuboAccess.Ipfs.PubSub, password: "testing");
-
-            var messageCount = 0;
             
-            var topic = "test";
-            var cs = new CancellationTokenSource();
-            try
-            {
-                await encryptedPubsub.SubscribeAsync(topic, msg =>
-                {
-                    Interlocked.Increment(ref messageCount);
-                }, cs.Token);
-
-                await encryptedPubsub.PublishAsync(topic, "hello world!");
-
-                await Task.Delay(1000);
-                Assert.AreEqual(1, messageCount);
-            }
-            finally
-            {
-                cs.Cancel();
-            }
+            await encryptedPubsub.PublishAsync("owlcore-kubo-test-runner", "hello world!");
         }
     }
 }

--- a/tests/OwlCore.Kubo.Tests/AesPasswordEncryptedPubSubTests.cs
+++ b/tests/OwlCore.Kubo.Tests/AesPasswordEncryptedPubSubTests.cs
@@ -8,9 +8,9 @@
         {
             await KuboAccess.TryInitAsync();
 
-            var encryptedPubsub = new AesPasswordEncryptedPubSub(KuboAccess.Ipfs.PubSub, password: "testing");
+            var encryptedPubsub = new AesPasswordEncryptedPubSub(KuboAccess.Ipfs.PubSub, password: "testing", salt: null);
             
-            await encryptedPubsub.PublishAsync("owlcore-kubo-test-runner", "hello world!");
+            await encryptedPubsub.PublishAsync(topic: "owlcore-kubo-test-runner", message: "hello world!");
         }
     }
 }

--- a/tests/OwlCore.Kubo.Tests/AesPasswordEncryptedPubSubTests.cs
+++ b/tests/OwlCore.Kubo.Tests/AesPasswordEncryptedPubSubTests.cs
@@ -1,0 +1,35 @@
+﻿namespace OwlCore.Kubo.Tests
+{
+    [TestClass]
+    public class AesPasswordEncryptedPubSubTests
+    {
+        [TestMethod]
+        public async Task PublishAsync()
+        {
+            await KuboAccess.TryInitAsync();
+
+            var encryptedPubsub = new AesPasswordEncryptedPubSub(KuboAccess.Ipfs.PubSub, password: "testing");
+
+            var messageCount = 0;
+            
+            var topic = "test";
+            var cs = new CancellationTokenSource();
+            try
+            {
+                await encryptedPubsub.SubscribeAsync(topic, msg =>
+                {
+                    Interlocked.Increment(ref messageCount);
+                }, cs.Token);
+
+                await encryptedPubsub.PublishAsync(topic, "hello world!");
+
+                await Task.Delay(1000);
+                Assert.AreEqual(1, messageCount);
+            }
+            finally
+            {
+                cs.Cancel();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `AesPasswordEncryptedPubSub`, a wrapper for existing IPubSubApi instances that automatically encrypts/decrypts messages using a pre-shared passkey.

Tests for this are difficult to write since it involved using 2 nodes, but I've tested both encryption and decryption locally on my machine. 

This also bumps the version number and updates the changelog.