### PR TITLE
Release 0.18.0

### DIFF
--- a/src/Downloader/KuboDistributionArchitecture.cs
+++ b/src/Downloader/KuboDistributionArchitecture.cs
@@ -1,8 +1,22 @@
 ﻿namespace OwlCore.Kubo;
 
+/// <summary>
+/// Represents an architecture for a Kubo distribution.
+/// </summary>
 public class KuboDistributionArchitecture
 {
+    /// <summary>
+    /// A relative download link for this architecture binary.
+    /// </summary>
     public string? Link { get; set; }
+    
+    /// <summary>
+    /// The Cid for this architecture binary.
+    /// </summary>
     public string? Cid { get; set; }
+    
+    /// <summary>
+    /// A hash that can be used to verify the downloaded data.
+    /// </summary>
     public string? Sha512 { get; set; }
 }

--- a/src/Downloader/KuboDistributionData.cs
+++ b/src/Downloader/KuboDistributionData.cs
@@ -1,16 +1,47 @@
-﻿using System;
-using System.Collections.Generic;
+﻿namespace OwlCore.Kubo;
 
-namespace OwlCore.Kubo;
-
+/// <summary>
+/// Represents data about a Kubo distribution.
+/// </summary>
 public class KuboDistributionData
 {
+    /// <summary>
+    /// A unique identifier for this distribution.
+    /// </summary>
     public string? Id { get; set; }
+    
+    /// <summary>
+    /// The version for this distribution.
+    /// </summary>
     public string? Version { get; set; }
+    
+    /// <summary>
+    /// The release link for this distribution.
+    /// </summary>
     public string? ReleaseLink { get; set; }
+    
+    /// <summary>
+    /// The name of this distribution.
+    /// </summary>
     public string? Name { get; set; }
+    
+    /// <summary>
+    /// The owner of this distribution.
+    /// </summary>
     public string? Owner { get; set; }
+    
+    /// <summary>
+    /// A description of this distribution.
+    /// </summary>
     public string? Description { get; set; }
+    
+    /// <summary>
+    /// The published date.
+    /// </summary>
     public string? Date { get; set; }
+    
+    /// <summary>
+    /// The platforms for this distribution.
+    /// </summary>
     public Dictionary<string, KuboDistributionPlatform>? Platforms { get; set; }
 }

--- a/src/Downloader/KuboDistributionJsonContext.cs
+++ b/src/Downloader/KuboDistributionJsonContext.cs
@@ -2,6 +2,9 @@
 
 namespace OwlCore.Kubo;
 
+/// <summary>
+/// Json context for serializing and deserializing <see cref="KuboDistributionData"/>.
+/// </summary>
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(KuboDistributionData))]
 public partial class KuboDistributionJsonContext : JsonSerializerContext

--- a/src/Downloader/KuboDistributionPlatform.cs
+++ b/src/Downloader/KuboDistributionPlatform.cs
@@ -1,9 +1,17 @@
-﻿using System.Collections.Generic;
+﻿namespace OwlCore.Kubo;
 
-namespace OwlCore.Kubo;
-
+/// <summary>
+/// Represents a distribution platform for Kubo.
+/// </summary>
 public class KuboDistributionPlatform
 {
+    /// <summary>
+    /// The name of the distribution platform.
+    /// </summary>
     public string? Name { get; set; }
+    
+    /// <summary>
+    /// The architectures available for this distribution.
+    /// </summary>
     public Dictionary<string, KuboDistributionArchitecture>? Archs { get; set; }
 }

--- a/src/Extensions/GenericKuboExtensions.cs
+++ b/src/Extensions/GenericKuboExtensions.cs
@@ -127,10 +127,10 @@ public static partial class GenericKuboExtensions
     /// <param name="client">The client to use for communicating with the ipfs network.</param>
     /// <param name="keyName">The name of the key to get or create.</param>
     /// <param name="ipnsLifetime">The lifetime this ipns key should stay alive before needing to be rebroadcast by this node.</param>
+    /// <param name="nocache">Whether to use Kubo's cache when resolving ipns keys.</param>
     /// <param name="size">The size of the key to create.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing task.</param>
     /// <param name="getDefaultValue">Given the created ipns key, provides the default value to be published to it.</param>
-    /// <returns></returns>
     public static async Task<(IKey Key, TResult Value)> GetOrCreateKeyAsync<TResult>(this ICoreApi client, string keyName, Func<IKey, TResult> getDefaultValue, TimeSpan ipnsLifetime, bool nocache, int size = 4096, CancellationToken cancellationToken = default)
     {
         // Get or create ipns key

--- a/src/IpfsFile.cs
+++ b/src/IpfsFile.cs
@@ -60,13 +60,12 @@ public class IpfsFile : IFile, IChildFile, IGetCid
         if (accessMode.HasFlag(FileAccess.Write))
             throw new NotSupportedException("Attempted to write data to an immutable file on IPFS.");
 
-        var fileData = await Client.Mfs.StatAsync($"/ipfs/{Id}", cancellationToken);
+        // Open and wrap ipfs stream
         var stream = await Client.FileSystem.ReadFileAsync(Id, cancellationToken);
-
+        var fileData = await Client.Mfs.StatAsync($"/ipfs/{Id}", cancellationToken);
         var streamWithLength = new LengthOverrideStream(stream, fileData.Size);
 
-        // Return in lazy seek-able wrapper.
-        return new LazySeekStream(streamWithLength);
+        return new ReadOnlyOverrideStream(streamWithLength);
     }
 
     /// <inheritdoc/>

--- a/src/KuboBootstrapper.cs
+++ b/src/KuboBootstrapper.cs
@@ -483,13 +483,14 @@ public class KuboBootstrapper : IDisposable
     /// Initializes the local node with the provided startup profile settings.
     /// </summary>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    protected virtual async Task ApplyStartupProfileSettingsAsync(CancellationToken cancellationToken)
+    protected virtual Task ApplyStartupProfileSettingsAsync(CancellationToken cancellationToken)
     {
         Guard.IsNotNullOrWhiteSpace(_kuboBinaryFile?.Path);
 
         // Startup profiles
         foreach (var profile in StartupProfiles)
             RunExecutable(_kuboBinaryFile, $"config --repo-dir \"{RepoPath}\" profile apply {profile}", throwOnError: true);
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -526,13 +527,14 @@ public class KuboBootstrapper : IDisposable
     /// Initializes the local node with the provided routing settings.
     /// </summary>
     /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-    protected virtual async Task ApplyRoutingSettingsAsync(CancellationToken cancellationToken)
+    protected virtual Task ApplyRoutingSettingsAsync(CancellationToken cancellationToken)
     {
         Guard.IsNotNullOrWhiteSpace(_kuboBinaryFile?.Path);
 
         RunExecutable(_kuboBinaryFile, $"config Routing.Type {RoutingMode.ToString().ToLowerInvariant()} --repo-dir \"{RepoPath}\"", throwOnError: true);
 
         RunExecutable(_kuboBinaryFile, $"config Routing.AcceleratedDHTClient \"{UseAcceleratedDHTClient.ToString().ToLower()}\" --json --repo-dir \"{RepoPath}\"", throwOnError: true);
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/MfsFolder.Modifiable.cs
+++ b/src/MfsFolder.Modifiable.cs
@@ -107,7 +107,7 @@ public partial class MfsFolder : IModifiableFolder, IMoveFrom, ICreateCopyOf
     /// <inheritdoc/>
     public virtual async Task<IChildFile> CreateFileAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
     {
-        await Client.Mfs.WriteAsync($"{Path}{name}", new MemoryStream(), new() { Create = true, Truncate = overwrite });
+        await Client.Mfs.WriteAsync($"{Path}{name}", new MemoryStream(), new() { Create = true, Truncate = overwrite }, cancellationToken);
 
         return new MfsFile($"{Path}{name}", Client);
     }

--- a/src/MfsFolder.cs
+++ b/src/MfsFolder.cs
@@ -74,7 +74,7 @@ public partial class MfsFolder : IFolder, IChildFolder, IGetItem, IGetItemRecurs
     }
 
     /// <inheritdoc/>
-    public virtual async Task<IStorableChild> GetFirstByNameAsync(string name, CancellationToken cancellationToken = new CancellationToken())
+    public virtual async Task<IStorableChild> GetFirstByNameAsync(string name, CancellationToken cancellationToken = default)
     {
         var mfsPath = $"{Id}{name}";
 

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;</TargetFrameworks>
     <Nullable>enable</Nullable>
@@ -14,13 +14,22 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.17.2</Version>
+    <Version>0.18.0</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
+--- 0.18.0 ---
+[Breaking]
+Inherited breaking changes from OwlCore.Storage 0.12.0 and OwlCore.ComponentModel 0.9.0.
+OwlCore.Kubo is no longer referencing the OwlCore meta-package, and is referencing required transient packages directly. Removes some uneeded transient dependencies that weren't required.
+Removed support for net6.0 and net7.0, as they are out of support. Only netstandard2.0 and net8.0 are supported.
+
+[Fixes]
+Inherited fixes from OwlCore.Storage 0.12.0 and OwlCore.ComponentModel 0.9.0.
+
 --- 0.17.2 ---
 [Fixes]
 Fixed an issue where CachedNameApi was using the 'nocache' parameter to determine whether to use the cache layer, instead of simply delegating to the underlying API. 'nocache' has nothing to do with the caching layer, the parameter is only used by the Kubo API.
@@ -428,16 +437,16 @@ Added unit tests.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Common" Version="8.2.2" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.Common" Version="8.3.0" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.3.0" />
     <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.5.0" />
-    <PackageReference Include="OwlCore" Version="0.6.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.8.1" />
-    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.0.0" />
-    <PackageReference Include="OwlCore.Extensions" Version="0.8.0" />
-    <PackageReference Include="OwlCore.Storage" Version="0.11.3" />
+    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.1.0" />
+    <PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.9.0" />
+    <PackageReference Include="OwlCore.Extensions" Version="0.9.0" />
+    <PackageReference Include="OwlCore.Storage" Version="0.12.0" />
     <PackageReference Include="OwlCore.Storage.SharpCompress" Version="0.1.0" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -26,9 +26,15 @@
 Inherited breaking changes from OwlCore.Storage 0.12.0 and OwlCore.ComponentModel 0.9.0.
 OwlCore.Kubo is no longer referencing the OwlCore meta-package, and is referencing required transient packages directly. Removes some uneeded transient dependencies that weren't required.
 Removed support for net6.0 and net7.0, as they are out of support. Only netstandard2.0 and net8.0 are supported.
+IpfsFile (and subsequently IpnsFile) no longer wraps the returned Stream in the LazySeekStream from OwlCore.ComponentModel. This can be applied separately if needed, but data larger than 2.1GB requires providing a custom backing stream.
 
 [Fixes]
 Inherited fixes from OwlCore.Storage 0.12.0 and OwlCore.ComponentModel 0.9.0.
+Fixed CancellationToken not being passed to underlying API in MfsFolder.CreateFileAsync.
+
+[Improvements]
+Refactor MfsStream class to use Path property instead of private field.
+Add missing code documentation to KuboDownloader json models.
 
 --- 0.17.2 ---
 [Fixes]

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/tests/OwlCore.Kubo.Tests/Extensions/StorageExtensions.cs
+++ b/tests/OwlCore.Kubo.Tests/Extensions/StorageExtensions.cs
@@ -1,0 +1,87 @@
+﻿using System.Runtime.CompilerServices;
+using OwlCore.Storage;
+
+namespace OwlCore.Kubo.Tests;
+
+public static class StorageExtensions
+{
+    public static async IAsyncEnumerable<IChildFile> CreateFilesAsync(this IModifiableFolder folder, int fileCount, Func<int, string> getFileName, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        for (var i = 0; i < fileCount; i++)
+            yield return await folder.CreateFileAsync(getFileName(i), overwrite: true, cancellationToken: cancellationToken);
+    }
+
+    public static async Task WriteRandomBytes(this IFile file, long numberOfBytes, int bufferSize, CancellationToken cancellationToken)
+    {
+        var rnd = new Random();
+
+        await using var fileStream = await file.OpenWriteAsync(cancellationToken);
+
+        var bytes = new byte[bufferSize];
+        var bytesWritten = 0L;
+        while (bytesWritten < numberOfBytes)
+        {
+            var remaining = numberOfBytes - bytesWritten;
+            
+            // Always runs if there are bytes left, even if there's fewer bytes left than the buffer.
+            // Truncate the buffer size to remaining length if smaller than buffer.
+            if (bufferSize > remaining)
+                bufferSize = (int)remaining;
+
+            if (bytes.Length != bufferSize)
+                bytes = new byte[bufferSize];
+            
+            rnd.NextBytes(bytes);
+
+            await fileStream.WriteAsync(bytes, cancellationToken);
+            bytesWritten += bufferSize;
+        }
+    }
+
+    public static async Task AssertStreamEqualAsync(this Stream srcFileStream, Stream destFileStream, int bufferSize, CancellationToken cancellationToken)
+    {
+        Assert.AreEqual(srcFileStream.Length, destFileStream.Length);
+
+        var totalBytes = srcFileStream.Length;
+        var bytesChecked = 0L;
+
+        var srcBuffer = new byte[bufferSize];
+        var destBuffer = new byte[bufferSize];
+
+        // Fill each buffer until bufferSize is reached.
+        // Each stream must fill the buffer until it is full,
+        // except if no bytes are left.
+        while (bytesChecked < totalBytes)
+        {
+            var srcBytesRead = 0;
+            while (srcBytesRead < srcBuffer.Length)
+            {
+                var srcBytesReadInternal = await srcFileStream.ReadAsync(srcBuffer, offset: srcBytesRead, count: srcBuffer.Length - srcBytesRead, cancellationToken);
+                if (srcBytesReadInternal == 0)
+                    break;
+
+                srcBytesRead += srcBytesReadInternal;
+            }
+
+
+            var destBytesRead = 0;
+            while (destBytesRead < destBuffer.Length)
+            {
+                var destBytesReadInternal = await destFileStream.ReadAsync(destBuffer, offset: destBytesRead, count: destBuffer.Length - destBytesRead, cancellationToken);
+                if (destBytesReadInternal == 0)
+                    break;
+
+                destBytesRead += destBytesReadInternal;
+            }
+
+            if (srcBytesRead != destBytesRead)
+            {
+                throw new InvalidOperationException($"Mismatch in bytes read between source and destination streams: {destBytesRead} and {srcBytesRead}.");
+            }
+
+            // When buffers are full, compare and continue.
+            CollectionAssert.AreEqual(destBuffer, srcBuffer);
+            bytesChecked += srcBytesRead;
+        }
+    }
+}

--- a/tests/OwlCore.Kubo.Tests/IpfsFileTests.cs
+++ b/tests/OwlCore.Kubo.Tests/IpfsFileTests.cs
@@ -1,10 +1,15 @@
-﻿namespace OwlCore.Kubo.Tests
+﻿using CommunityToolkit.Diagnostics;
+using OwlCore.Storage;
+using OwlCore.Storage.System.IO;
+using OwlCore.Storage.System.Net.Http;
+
+namespace OwlCore.Kubo.Tests
 {
     [TestClass]
     public class IpfsFileTests
     {
         [TestMethod]
-        public async Task BasicFileReadTest()
+        public async Task BasicFileRead_RpcApi_Test()
         {
             var file = new IpfsFile("Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD", TestFixture.Client);
             using var stream = await file.OpenStreamAsync();
@@ -13,6 +18,68 @@
             var txt = await text.ReadToEndAsync();
 
             Assert.AreEqual("hello world", txt);
+        }
+
+        [TestMethod]
+        public async Task BasicFileRead_Gateway_Test()
+        {
+            Guard.IsNotNull(TestFixture.Bootstrapper);
+
+            var file = new HttpFile($"{TestFixture.Bootstrapper.GatewayUri}/ipfs/Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD");
+            var txt = await file.ReadTextAsync();
+
+            Assert.AreEqual("hello world", txt);
+        }
+
+        [TestMethod]
+        public async Task BasicFileRead_RpcApi_LargeFile_Test()
+        {
+            var bufferSize = 4096;
+            var totalFileSize = (long)int.MaxValue + 1024;
+
+            // Generate a large file
+            var workingFile = new SystemFile(Path.GetTempFileName());
+            await workingFile.WriteRandomBytes(totalFileSize, bufferSize, CancellationToken.None);
+
+            // Upload large file via RPC API
+            using var srcFileStream = await workingFile.OpenReadAsync();
+            var added = await TestFixture.Client.FileSystem.AddAsync(srcFileStream);
+            srcFileStream.Position = 0;
+
+            // Test with IpfsFile.
+            var file = new IpfsFile(added.Id, TestFixture.Client);
+            using var destFileStream = await file.OpenStreamAsync();
+
+            Assert.AreEqual(srcFileStream.Length, totalFileSize);
+            Assert.AreEqual(destFileStream.Length, totalFileSize);
+
+            await srcFileStream.AssertStreamEqualAsync(destFileStream, bufferSize, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task BasicFileRead_Gateway_LargeFile_Test()
+        {
+            Guard.IsNotNull(TestFixture.Bootstrapper);
+            var bufferSize = 4096;
+            var totalFileSize = (long)int.MaxValue + 1024;
+            
+            // Generate a large file
+            var sourceFile = new SystemFile(Path.GetTempFileName());
+            await sourceFile.WriteRandomBytes(totalFileSize, bufferSize, CancellationToken.None);
+
+            // Upload large file via RPC API
+            var srcFileStream = await sourceFile.OpenReadAsync();
+            var added = await TestFixture.Client.FileSystem.AddAsync(srcFileStream);
+            srcFileStream.Position = 0;
+
+            // Open large file via http gateway
+            var destFile = new HttpFile($"{TestFixture.Bootstrapper.GatewayUri}/ipfs/{added.Id}");
+            using var destFileStream = await destFile.OpenReadAsync();
+
+            Assert.AreEqual(srcFileStream.Length, totalFileSize);
+            Assert.AreEqual(destFileStream.Length, totalFileSize);
+
+            await srcFileStream.AssertStreamEqualAsync(destFileStream, bufferSize, CancellationToken.None);
         }
     }
 }

--- a/tests/OwlCore.Kubo.Tests/LoopbackPubSubApi.cs
+++ b/tests/OwlCore.Kubo.Tests/LoopbackPubSubApi.cs
@@ -46,7 +46,7 @@ public class LoopbackPubSubApi : IPubSubApi
             }
         }
 
-        await _loopbackApis.InParallel(x =>
+        await _loopbackApis.ToArray().InParallel(x =>
         {
             if (cancel.IsCancellationRequested)
                 return Task.CompletedTask;
@@ -69,7 +69,7 @@ public class LoopbackPubSubApi : IPubSubApi
         _handlers.TryAdd(topic, new HashSet<Action<IPublishedMessage>>());
         _handlers[topic].Add(handler);
 
-        return _loopbackApis.InParallel(x =>
+        return _loopbackApis.ToArray().InParallel(x =>
         {
             if (cancellationToken.IsCancellationRequested)
                 return Task.CompletedTask;

--- a/tests/OwlCore.Kubo.Tests/OwlCore.Kubo.Tests.csproj
+++ b/tests/OwlCore.Kubo.Tests/OwlCore.Kubo.Tests.csproj
@@ -4,17 +4,23 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="OwlCore.Extensions" Version="0.9.0" />
+    <PackageReference Include="PolySharp" Version="1.14.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/tests/OwlCore.Kubo.Tests/PeerRoomTests.cs
+++ b/tests/OwlCore.Kubo.Tests/PeerRoomTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Text;
+using CommunityToolkit.Diagnostics;
 using Ipfs;
 
 namespace OwlCore.Kubo.Tests;
@@ -88,6 +89,7 @@ public class PeerRoomTests
         secondPeerRoom.MessageReceived += (sender, message) =>
         {
             // Peer room must not emit messages from the sender peer.
+            Guard.IsNotNull(sender);
             var room = (PeerRoom)sender;
             Assert.AreNotEqual(room.ThisPeer.Id, message.Sender.Id);
 

--- a/tests/OwlCore.Kubo.Tests/TestFixture.cs
+++ b/tests/OwlCore.Kubo.Tests/TestFixture.cs
@@ -58,7 +58,6 @@ public class TestFixture
         {
             ApiUri = new Uri($"http://127.0.0.1:{apiPort}"),
             GatewayUri = new Uri($"http://127.0.0.1:{gatewayPort}"),
-            BinaryWorkingFolder = workingDirectory,
             RoutingMode = DhtRoutingMode.AutoClient,
             LaunchConflictMode = BootstrapLaunchConflictMode.Relaunch,
         };


### PR DESCRIPTION
This release contains various fixes and improvements, especially around the reading of files larger than 2.1GB. 

- **Removed support for net6.0 and net7.0, as they are out of support. Only netstandard2.0 and net8.0 are supported.**
- **Version bump to 0.18.0, add initial release notes. Update dependencies.**
- **IpfsFile no longer wraps the returned Stream in the LazySeekStream from OwlCore.ComponentModel.**
- **Remove async keyword from ApplyStartupProfileSettingsAsync and ApplyRoutingSettingsAsync methods**
- **Use default instead of new CancellationToken in  GetFirstByNameAsync method signature**
- **Fixed CancellationToken not being passed to underlying API in MfsFolder.CreateFileAsync.**
- **Refactor MfsStream class to use Path property instead of private field**
- **Add missing code documentation**
- **Refactor IpfsFileTests to include additional test methods for reading large files from RPC API and Gateway**
- **Refactor PeerRoomTests to add null check for sender in MessageReceived event handler**
- **Use temp as binary folder for tests**
- **Update test project dependencies**
- **Update package release notes with latest changes.**
