### PR TITLE
Release 0.19.0. Fixes and improvements to MfsStream and IGetCid storage extensions.

### DIFF
--- a/src/Extensions/IAddFileToGetCid.cs
+++ b/src/Extensions/IAddFileToGetCid.cs
@@ -1,0 +1,19 @@
+using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.Storage;
+
+namespace OwlCore.Kubo;
+
+/// <summary>
+/// Implementations are capable of providing a CID for the current content by adding it ipfs.
+/// </summary>
+public partial interface IAddFileToGetCid : IStorable
+{
+    /// <summary>
+    /// Gets the CID of the storable item.
+    /// </summary>
+    /// <param name="addFileOptions">The add file options to use when computing the cid for this storable.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns></returns>
+    public Task<Cid> GetCidAsync(AddFileOptions addFileOptions, CancellationToken cancellationToken);
+}

--- a/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFile.cs
+++ b/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFile.cs
@@ -8,7 +8,7 @@ namespace OwlCore.Storage.System.IO;
 /// <summary>
 /// An implementation of <see cref="SystemFile"/> with added support for <see cref="IGetCid"/>.
 /// </summary>
-public class ContentAddressedSystemFile : SystemFile, IGetCid
+public class ContentAddressedSystemFile : SystemFile, IAddFileToGetCid
 {
     /// <summary>
     /// Creates a new instance of <see cref="SystemFile"/>.
@@ -27,13 +27,9 @@ public class ContentAddressedSystemFile : SystemFile, IGetCid
     public ICoreApi Client { get; }
 
     /// <inheritdoc/>
-    public async Task<Cid> GetCidAsync(CancellationToken cancellationToken)
+    public async Task<Cid> GetCidAsync(AddFileOptions addFileOptions, CancellationToken cancellationToken)
     {
-        var res = await Client.FileSystem.AddFileAsync(Id, new()
-        {
-            OnlyHash = true,
-            Pin = false
-        }, cancellationToken);
+        var res = await Client.FileSystem.AddFileAsync(Id, addFileOptions, cancellationToken);
 
         Guard.IsFalse(res.IsDirectory);
         return res.ToLink().Id;

--- a/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFolder.cs
+++ b/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFolder.cs
@@ -8,7 +8,7 @@ namespace OwlCore.Storage.System.IO;
 /// <summary>
 /// An implementation of <see cref="SystemFolder"/> with added support for <see cref="IGetCid"/>.
 /// </summary>
-public class ContentAddressedSystemFolder : SystemFolder, IGetCid
+public class ContentAddressedSystemFolder : SystemFolder, IAddFileToGetCid
 {
     /// <summary>
     /// Creates a new instance of <see cref="SystemFolder"/>.
@@ -27,13 +27,9 @@ public class ContentAddressedSystemFolder : SystemFolder, IGetCid
     public ICoreApi Client { get; }
 
     /// <inheritdoc/>
-    public async Task<Cid> GetCidAsync(CancellationToken cancellationToken)
+    public async Task<Cid> GetCidAsync(AddFileOptions addFileOptions, CancellationToken cancellationToken)
     {
-        var res = await Client.FileSystem.AddDirectoryAsync(Id, recursive: true, new()
-        {
-            OnlyHash = true,
-            Pin = false,
-        }, cancellationToken);
+        var res = await Client.FileSystem.AddDirectoryAsync(Id, recursive: true, addFileOptions, cancellationToken);
 
         Guard.IsTrue(res.IsDirectory);
         return res.ToLink().Id;

--- a/src/IpnsFolder.cs
+++ b/src/IpnsFolder.cs
@@ -71,7 +71,7 @@ public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGet
     /// <inheritdoc />
     public virtual async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var cid = await GetCidAsync(cancellationToken);
+        var cid = await GetCidAsync(Id, cancellationToken);
         var itemInfo = await Client.FileSystem.ListAsync(cid, cancellationToken);
         Guard.IsTrue(itemInfo.IsDirectory);
 

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -14,13 +14,30 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.18.0</Version>
+    <Version>0.19.0</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
+--- 0.19.0 ---
+[New]
+Added IAddFileToGetCid interface. This is functionally identical to IGetCid, but instead of simply returning a CID already in ipfs, it computes the CID by providing data to ipfs using preferences in the AddFileOptions parameter.
+
+[Breaking]
+StorableKuboExtensions.GetCidAsync now takes an AddFileOptions parameter.
+ContentAddressedSystemFile and ContentAddressedSystemFolder now implement IAddFileToGetCid instead of IGetCid.
+
+[Fixes]
+Inherited fixes from OwlCore.ComponentModel 0.9.1.
+Fixed issues with MfsStream where it would return before the task was complete.
+MfsStream.ReadAsync and MfsStream.WriteAsync now respect the requested offset when operating on the provided buffer.
+
+[Improvement]
+Updated to IpfsShipyard.Ipfs.Http.Client 0.5.1.
+MfsStream.WriteAsync now supplies Flush = false when writing to mfs, instead of the default of flushing after every write. This improves performance when writing large files, but requires a manual call to FlushAsync to persist the changes. 
+
 --- 0.18.0 ---
 [Breaking]
 Inherited breaking changes from OwlCore.Storage 0.12.0 and OwlCore.ComponentModel 0.9.0.
@@ -443,15 +460,15 @@ Added unit tests.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Common" Version="8.3.0" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.3.0" />
-    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.5.0" />
+    <PackageReference Include="CommunityToolkit.Common" Version="8.3.1" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.3.1" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.5.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.1.0" />
+    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.1.1" />
     <PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.9.0" />
-    <PackageReference Include="OwlCore.Extensions" Version="0.9.0" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.9.1" />
+    <PackageReference Include="OwlCore.Extensions" Version="0.9.1" />
     <PackageReference Include="OwlCore.Storage" Version="0.12.0" />
     <PackageReference Include="OwlCore.Storage.SharpCompress" Version="0.1.0" />
     <PackageReference Include="PolySharp" Version="1.14.1">

--- a/tests/OwlCore.Kubo.Tests/OwlCore.Kubo.Tests.csproj
+++ b/tests/OwlCore.Kubo.Tests/OwlCore.Kubo.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OwlCore.Extensions" Version="0.9.0" />
+    <PackageReference Include="OwlCore.Extensions" Version="0.9.1" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
[New]
Added IAddFileToGetCid interface. This is functionally identical to IGetCid, but instead of simply returning a CID already in ipfs, it computes the CID by providing data to ipfs using preferences in the AddFileOptions parameter.

[Breaking]
StorableKuboExtensions.GetCidAsync now takes an AddFileOptions parameter.
ContentAddressedSystemFile and ContentAddressedSystemFolder now implement IAddFileToGetCid instead of IGetCid.

[Fixes]
Inherited fixes from OwlCore.ComponentModel 0.9.1.
Fixed issues with MfsStream where it would return before the task was complete.
MfsStream.ReadAsync and MfsStream.WriteAsync now respect the requested offset when operating on the provided buffer.

[Improvement]
Updated to IpfsShipyard.Ipfs.Http.Client 0.5.1.
MfsStream.WriteAsync now supplies Flush = false when writing to mfs, instead of the default of flushing after every write. This improves performance when writing large files, but requires a manual call to FlushAsync to persist the changes.
