### PR TITLE
Release 0.20.0. Filesystem improvements, Filestore support

### DIFF
--- a/src/AesPasswordEncryptedPubSub.cs
+++ b/src/AesPasswordEncryptedPubSub.cs
@@ -111,7 +111,7 @@ public class AesPasswordEncryptedPubSub : IPubSubApi, IDelegable<IPubSubApi>
             var outputBytes = outputStream.ToBytes();
 
             outputStream.Seek(0, SeekOrigin.Begin);
-            return new PublishedMessage(publishedMessage.Sender, publishedMessage.Topics, publishedMessage.SequenceNumber, outputBytes, outputStream, publishedMessage.Size);
+            return new PublishedMessage(publishedMessage.Sender, publishedMessage.Topics, publishedMessage.SequenceNumber, outputBytes);
         }
         catch
         {

--- a/src/Cache/CachedCoreApi.cs
+++ b/src/Cache/CachedCoreApi.cs
@@ -66,9 +66,6 @@ public class CachedCoreApi : ICoreApi, IDelegable<ICoreApi>, IFlushable, IAsyncI
     public INameApi Name { get; }
 
     /// <inheritdoc/>
-    public IObjectApi Object => Inner.Object;
-
-    /// <inheritdoc/>
     public IPinApi Pin => Inner.Pin;
 
     /// <inheritdoc/>

--- a/src/Extensions/GenericKuboExtensions.cs
+++ b/src/Extensions/GenericKuboExtensions.cs
@@ -26,7 +26,7 @@ public static partial class GenericKuboExtensions
             cid = Cid.Decode(ipnsResResult.Replace("/ipfs/", ""));
         }
 
-        var res = await client.Dag.GetAsync<TResult>(cid, cancellationToken);
+        var res = await client.Dag.GetAsync<TResult>(cid, cancel: cancellationToken);
 
         Guard.IsNotNull(res);
         return (res, cid);
@@ -49,7 +49,7 @@ public static partial class GenericKuboExtensions
             cid = Cid.Decode(ipnsResResult.Replace("/ipfs/", ""));
         }
 
-        var res = await client.Dag.GetAsync<TResult>(cid, cancellationToken);
+        var res = await client.Dag.GetAsync<TResult>(cid, cancel: cancellationToken);
 
         return (res, cid);
     }

--- a/src/Extensions/IpnsDagExtensions.cs
+++ b/src/Extensions/IpnsDagExtensions.cs
@@ -37,7 +37,7 @@ public static partial class IpnsDagExtensions
 
         // Resolve data
         progress?.Report(IpnsUpdateState.ResolvingDag);
-        var data = await client.Dag.GetAsync<TTransformType>(cid, cancellationToken);
+        var data = await client.Dag.GetAsync<TTransformType>(cid, cancel: cancellationToken);
         if (data is null)
             throw new InvalidOperationException("Failed to resolve data from the provided CID.");
         

--- a/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFolder.cs
+++ b/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFolder.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Diagnostics;
+﻿using System.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
 using OwlCore.Kubo;
@@ -29,9 +30,42 @@ public class ContentAddressedSystemFolder : SystemFolder, IAddFileToGetCid
     /// <inheritdoc/>
     public async Task<Cid> GetCidAsync(AddFileOptions addFileOptions, CancellationToken cancellationToken)
     {
-        var res = await Client.FileSystem.AddDirectoryAsync(Id, recursive: true, addFileOptions, cancellationToken);
+        FilePart[] fileParts = [];
+        FolderPart[] folderParts = [new FolderPart { Name = Name }];
 
-        Guard.IsTrue(res.IsDirectory);
-        return res.ToLink().Id;
+        // Get child file and folder parts recursively
+        var q = new Queue<SystemFolder>([this]);
+        while (q.Count > 0)
+        {
+            await foreach (var item in q.Dequeue().GetItemsAsync(StorableType.All, cancellationToken))
+            {
+                var relativePath = await this.GetRelativePathToAsync(item, cancellationToken);
+                var adjustedRelativePath = $"{Name}{relativePath}";
+                
+                if (item is SystemFile file)
+                {
+                    fileParts = [.. fileParts, new FilePart { Name = adjustedRelativePath, Data = new FileStream(file.Path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous), AbsolutePath = file.Path }];
+                }
+                else if (item is SystemFolder folder)
+                {
+                    folderParts = [.. folderParts, new FolderPart { Name = adjustedRelativePath }];
+                    q.Enqueue(folder);
+                }
+            }
+        }
+
+        Cid? rootCid = null;
+
+        await foreach (var node in Client.FileSystem.AddAsync(fileParts, folderParts, addFileOptions, cancellationToken))
+        {
+            var filePart = fileParts.FirstOrDefault(x => x.Name == node.Name);
+            filePart?.Data?.Dispose();
+
+            if (node.Name == Name)
+                rootCid = node.Id;
+        }
+        
+        Guard.IsNotNull(rootCid);
+        return rootCid;
     }
 }

--- a/src/Models/PublishedMessage.cs
+++ b/src/Models/PublishedMessage.cs
@@ -11,14 +11,12 @@ public class PublishedMessage : IPublishedMessage
     /// <summary>
     /// Creates a new instance of <see cref="PublishedMessage"/>.
     /// </summary>
-    public PublishedMessage(Peer sender, IEnumerable<string> topics, byte[] sequenceNumber, byte[] dataBytes, Stream dataStream, long size)
+    public PublishedMessage(Peer sender, IEnumerable<string> topics, byte[] sequenceNumber, byte[] dataBytes)
     {
         Sender = sender;
         Topics = topics;
         SequenceNumber = sequenceNumber;
         DataBytes = dataBytes;
-        DataStream = dataStream;
-        Size = size;
     }
 
     /// <inheritdoc/>
@@ -32,13 +30,4 @@ public class PublishedMessage : IPublishedMessage
 
     /// <inheritdoc/>
     public byte[] DataBytes { get; }
-
-    /// <inheritdoc/>
-    public Stream DataStream { get; }
-
-    /// <inheritdoc/>
-    public Cid Id { get; } = MultiHash.ComputeHash(Encoding.UTF8.GetBytes(nameof(PublishedMessage)));
-
-    /// <inheritdoc/>
-    public long Size { get; }
 }

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -14,13 +14,24 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.19.1</Version>
+    <Version>0.20.0</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
+--- 0.20.0 ---
+[Improvements]
+Upgraded IpfsShipyard.Ipfs.Http.Client to 0.6.0 with numerous notable improvements and breaking fixes.
+Added KuboBootstrapper.EnableFilestore flag for use in tandem with the `NoCopy` option now available in the underlying API.
+GetCidAsync supports the new `NoCopy` and all other AddFileOptions in the underlying API.
+ContentAddressedSystemFolder supports the new `NoCopy` and automatically handles absolute paths for the filestore to use.
+GetCidAsync now uses the new FilesystemApi.AddAsync method as the fallback implementation to crawl and upload an entire directory structure for any OwlCore.Storage implementation. 
+
+[Breaking]
+See inherited breaking changes in IpfsShipyard.Ipfs.Core 0.7.0 and IpfsShipyard.Ipfs.Http.Client 0.6.0 release notes. 
+
 --- 0.19.1 ---
 [Improvements]
 Updated vulnerable System.Text.Json to latest stable 9.0.0.
@@ -468,7 +479,7 @@ Added unit tests.
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Common" Version="8.3.2" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.3.2" />
-    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.5.1" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.6.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.1.1" />

--- a/tests/OwlCore.Kubo.Tests/Extensions/StorageExtensions.cs
+++ b/tests/OwlCore.Kubo.Tests/Extensions/StorageExtensions.cs
@@ -11,11 +11,9 @@ public static class StorageExtensions
             yield return await folder.CreateFileAsync(getFileName(i), overwrite: true, cancellationToken: cancellationToken);
     }
 
-    public static async Task WriteRandomBytes(this IFile file, long numberOfBytes, int bufferSize, CancellationToken cancellationToken)
+    public static async Task WriteRandomBytesAsync(this IFile file, long numberOfBytes, int bufferSize, CancellationToken cancellationToken)
     {
-        var rnd = new Random();
-
-        await using var fileStream = await file.OpenWriteAsync(cancellationToken);
+        var fileStream = await file.OpenWriteAsync(cancellationToken);
 
         var bytes = new byte[bufferSize];
         var bytesWritten = 0L;
@@ -30,12 +28,14 @@ public static class StorageExtensions
 
             if (bytes.Length != bufferSize)
                 bytes = new byte[bufferSize];
-            
-            rnd.NextBytes(bytes);
+
+            Random.Shared.NextBytes(bytes);
 
             await fileStream.WriteAsync(bytes, cancellationToken);
             bytesWritten += bufferSize;
         }
+        
+        await fileStream.DisposeAsync();
     }
 
     public static async Task AssertStreamEqualAsync(this Stream srcFileStream, Stream destFileStream, int bufferSize, CancellationToken cancellationToken)

--- a/tests/OwlCore.Kubo.Tests/FilestoreTests.cs
+++ b/tests/OwlCore.Kubo.Tests/FilestoreTests.cs
@@ -1,0 +1,51 @@
+﻿using OwlCore.Storage.System.IO;
+using System.Diagnostics;
+using System.Text;
+using CommunityToolkit.Diagnostics;
+using OwlCore.Storage;
+
+namespace OwlCore.Kubo.Tests
+{
+    [TestClass]
+    public class FilestoreTests
+    {
+        [TestMethod]
+        public async Task TestFilestoreAsync()
+        {
+            Guard.IsNotNull(TestFixture.Bootstrapper);
+            var client = TestFixture.Client;
+
+            var workingFolder = (IModifiableFolder?)await TestFixture.Bootstrapper.RepoFolder.GetParentAsync();
+            Guard.IsNotNull(workingFolder);
+            
+            var testFolder = (SystemFolder)await workingFolder.CreateFolderAsync("in", overwrite: true);
+
+            // Create random data in working folder
+            await foreach (var file in testFolder.CreateFilesAsync(2, i => $"{i}.bin", CancellationToken.None))
+                await file.WriteRandomBytesAsync(512, 512, CancellationToken.None);
+
+            // Add the same data to filestore
+            var filestoreFolderCid = await testFolder.GetCidAsync(client, new Ipfs.CoreApi.AddFileOptions { NoCopy = true, CidVersion = 1, }, default);
+
+            // List the filestore
+            var items = await client.Filestore.ListAsync().ToListAsync();
+            Assert.AreEqual(2, items.Count);
+
+            // Verify duplicate don't exist yet
+            var duplicates = await client.Filestore.DupsAsync().ToListAsync();
+            Assert.AreEqual(0, duplicates.Count);
+
+            // Add to ipfs (without filestore)
+            var folderCid = await testFolder.GetCidAsync(client, new Ipfs.CoreApi.AddFileOptions { NoCopy = false, RawLeaves = true, CidVersion = 1, }, default);
+            Assert.AreEqual(folderCid, filestoreFolderCid);
+
+            // Verify the filestore
+            items = await client.Filestore.VerifyObjectsAsync().ToListAsync();
+            Assert.AreEqual(2, items.Count);
+
+            // Verify duplicates now exist
+            duplicates = await client.Filestore.DupsAsync().ToListAsync();
+            Assert.AreEqual(2, duplicates.Count);
+        }
+    }
+}

--- a/tests/OwlCore.Kubo.Tests/IpfsFileTests.cs
+++ b/tests/OwlCore.Kubo.Tests/IpfsFileTests.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Diagnostics;
+using Ipfs.CoreApi;
 using OwlCore.Storage;
 using OwlCore.Storage.System.IO;
 using OwlCore.Storage.System.Net.Http;
@@ -39,11 +40,11 @@ namespace OwlCore.Kubo.Tests
 
             // Generate a large file
             var workingFile = new SystemFile(Path.GetTempFileName());
-            await workingFile.WriteRandomBytes(totalFileSize, bufferSize, CancellationToken.None);
+            await workingFile.WriteRandomBytesAsync(totalFileSize, bufferSize, CancellationToken.None);
 
             // Upload large file via RPC API
             using var srcFileStream = await workingFile.OpenReadAsync();
-            var added = await TestFixture.Client.FileSystem.AddAsync(srcFileStream);
+            var added = await TestFixture.Client.FileSystem.AddAsync([new FilePart { AbsolutePath = workingFile.Path, Data = srcFileStream, Name = workingFile.Name }], []).FirstAsync();
             srcFileStream.Position = 0;
 
             // Test with IpfsFile.
@@ -65,11 +66,11 @@ namespace OwlCore.Kubo.Tests
             
             // Generate a large file
             var sourceFile = new SystemFile(Path.GetTempFileName());
-            await sourceFile.WriteRandomBytes(totalFileSize, bufferSize, CancellationToken.None);
+            await sourceFile.WriteRandomBytesAsync(totalFileSize, bufferSize, CancellationToken.None);
 
             // Upload large file via RPC API
             var srcFileStream = await sourceFile.OpenReadAsync();
-            var added = await TestFixture.Client.FileSystem.AddAsync(srcFileStream);
+            var added = await TestFixture.Client.FileSystem.AddAsync([new FilePart { AbsolutePath = sourceFile.Path, Data = srcFileStream, Name = sourceFile.Name }], []).FirstAsync();
             srcFileStream.Position = 0;
 
             // Open large file via http gateway

--- a/tests/OwlCore.Kubo.Tests/LoopbackPubSubApi.cs
+++ b/tests/OwlCore.Kubo.Tests/LoopbackPubSubApi.cs
@@ -42,7 +42,7 @@ public class LoopbackPubSubApi : IPubSubApi
             {
                 var bytes = await message.ToBytesAsync(cancel);
                 message.Seek(0, SeekOrigin.Begin);
-                handler(new PublishedMessage(_senderPeer, topic.IntoList(), Array.Empty<byte>(), bytes, new MemoryStream(bytes), bytes.Length));
+                handler(new PublishedMessage(_senderPeer, topic.IntoList(), Array.Empty<byte>(), bytes));
             }
         }
 

--- a/tests/OwlCore.Kubo.Tests/TestFixture.cs
+++ b/tests/OwlCore.Kubo.Tests/TestFixture.cs
@@ -60,11 +60,14 @@ public class TestFixture
             GatewayUri = new Uri($"http://127.0.0.1:{gatewayPort}"),
             RoutingMode = DhtRoutingMode.AutoClient,
             LaunchConflictMode = BootstrapLaunchConflictMode.Relaunch,
+            BinaryWorkingFolder = workingDirectory,
+            EnableFilestore = true,
         };
 
         OwlCore.Diagnostics.Logger.LogInformation($"Starting node {nodeRepoName}\n");
 
         await node.StartAsync();
+        await node.Client.IdAsync();
 
         Assert.IsNotNull(node.Process);
         return node;


### PR DESCRIPTION
[Improvements]
Upgraded IpfsShipyard.Ipfs.Http.Client to 0.6.0 with numerous notable improvements and breaking fixes.
Added KuboBootstrapper.EnableFilestore flag for use in tandem with the `NoCopy` option now available in the underlying API.
GetCidAsync supports the new `NoCopy` and all other AddFileOptions in the underlying API.
ContentAddressedSystemFolder supports the new `NoCopy` and automatically handles absolute paths for the filestore to use.
GetCidAsync now uses the new FilesystemApi.AddAsync method as the fallback implementation to crawl and upload an entire directory structure for any OwlCore.Storage implementation.

[Breaking]
See inherited breaking changes in IpfsShipyard.Ipfs.Core 0.7.0 and IpfsShipyard.Ipfs.Http.Client 0.6.0 release notes.