### PR TITLE
Release 0.20.2

### DIFF
--- a/src/Extensions/GenericKuboExtensions.cs
+++ b/src/Extensions/GenericKuboExtensions.cs
@@ -19,6 +19,8 @@ public static partial class GenericKuboExtensions
     /// <returns>The deserialized DAG content, if any.</returns>
     public static async Task<(TResult? Result, Cid ResultCid)> ResolveDagCidAsync<TResult>(this Cid cid, ICoreApi client, bool nocache, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        
         if (cid.ContentType == "libp2p-key")
         {
             var ipnsResResult = await client.Name.ResolveAsync($"/ipns/{cid}", recursive: true, nocache: nocache, cancel: cancellationToken);
@@ -42,6 +44,8 @@ public static partial class GenericKuboExtensions
     /// <returns>The deserialized DAG content, if any.</returns>
     public static async Task<(TResult? Result, Cid ResultCid)> ResolveDagCidAsync<TResult>(this ICoreApi client, Cid cid, bool nocache, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        
         if (cid.ContentType == "libp2p-key")
         {
             var ipnsResResult = await client.Name.ResolveAsync($"/ipns/{cid}", recursive: true, nocache: nocache, cancel: cancellationToken);
@@ -94,6 +98,8 @@ public static partial class GenericKuboExtensions
     /// <returns>A task containing the created key.</returns>
     public static async Task<IKey> CreateKeyWithNameOfIdAsync(this IKeyApi keyApi, int size = 4096, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        
         var key = await keyApi.CreateAsync(name: "temp", "ed25519", size, cancellationToken);
 
         // Rename key name to the key id
@@ -110,6 +116,8 @@ public static partial class GenericKuboExtensions
     /// <returns></returns>
     public static async Task<IKey> GetOrCreateKeyAsync(this IKeyApi keyApi, string keyName, int size = 4096, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        
         // Get or create ipns key
         var keys = await keyApi.ListAsync(cancellationToken);
         if (keys.FirstOrDefault(x => x.Name == keyName) is not { } key)
@@ -133,6 +141,8 @@ public static partial class GenericKuboExtensions
     /// <param name="getDefaultValue">Given the created ipns key, provides the default value to be published to it.</param>
     public static async Task<(IKey Key, TResult Value)> GetOrCreateKeyAsync<TResult>(this ICoreApi client, string keyName, Func<IKey, TResult> getDefaultValue, TimeSpan ipnsLifetime, bool nocache, int size = 4096, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        
         // Get or create ipns key
         var keys = await client.Key.ListAsync(cancellationToken);
         if (keys.FirstOrDefault(x => x.Name == keyName) is not { } key)

--- a/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFile.cs
+++ b/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFile.cs
@@ -32,6 +32,12 @@ public class ContentAddressedSystemFile : SystemFile, IAddFileToGetCid
         var fileStream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize, FileOptions.Asynchronous);
         var res = await Client.FileSystem.AddAsync([new FilePart { Name = Name, Data = fileStream, AbsolutePath = Path }], [], addFileOptions, cancellationToken).FirstAsync();
 
+#if NET5_0_OR_GREATER
+        await fileStream.DisposeAsync();
+#else
+        fileStream.Dispose();
+#endif
+
         Guard.IsFalse(res.IsDirectory);
         return res.ToLink().Id;
     }

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -14,13 +14,20 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.20.1</Version>
+    <Version>0.20.2</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
+--- 0.20.2 ---
+[Fixes]
+Fix file stream disposal in ContentAddressedSystemFile.GetCidAsync.
+
+[Improvements]
+Add cancellation checks on entry for all async methods in GenericKuboExtensions.
+
 --- 0.20.1 ---
 [Fixes]
 Added NoCopy (filestore) support to ContentAddressedSystemFile.GetCidAsync().


### PR DESCRIPTION
[Fixes]
Fix file stream disposal in ContentAddressedSystemFile.GetCidAsync.

[Improvements]
Add cancellation checks on entry for all async methods in GenericKuboExtensions.