### PR TITLE
Release 0.21.0

### DIFF
--- a/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFile.cs
+++ b/src/Extensions/OwlCore.Storage.System.IO/ContentAddressedSystemFile.cs
@@ -29,8 +29,9 @@ public class ContentAddressedSystemFile : SystemFile, IAddFileToGetCid
     /// <inheritdoc/>
     public async Task<Cid> GetCidAsync(AddFileOptions addFileOptions, CancellationToken cancellationToken)
     {
-        var fileStream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize, FileOptions.Asynchronous);
-        var res = await Client.FileSystem.AddAsync([new FilePart { Name = Name, Data = fileStream, AbsolutePath = Path }], [], addFileOptions, cancellationToken).FirstAsync();
+        var fileStream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.Read, BufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        var res = await Client.FileSystem.AddAsync([new FilePart { Name = Name, Data = fileStream, AbsolutePath = Path }], [], addFileOptions, cancellationToken).FirstAsync(cancellationToken: cancellationToken);
 
 #if NET5_0_OR_GREATER
         await fileStream.DisposeAsync();

--- a/src/Extensions/StorableKuboExtensions.cs
+++ b/src/Extensions/StorableKuboExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
-using Ipfs.Http;
 using OwlCore.Storage;
 using OwlCore.Storage.System.IO;
 

--- a/src/IpnsFile.cs
+++ b/src/IpnsFile.cs
@@ -18,7 +18,22 @@ public class IpnsFile : IFile, IChildFile, IGetCid
     public IpnsFile(string ipnsAddress, ICoreApi client)
     {
         Id = ipnsAddress;
-        Name = PathHelpers.GetFolderItemName(ipnsAddress);
+        // Handle named files in ipns addresses, both in folders and directly published to the root of an IPNS address.
+        // An IPNS address usually only has a filename in the path query if the published ipns value is a file and not a folder, otherwise names are assigned via the folder.
+        Name = PathHelpers.TryGetFileNameFromPathQuery(ipnsAddress) ?? PathHelpers.GetFolderItemName(ipnsAddress);
+        Client = client;
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="IpnsFile"/>.
+    /// </summary>
+    /// <param name="ipnsAddress">A resolvable IPNS address, such as "ipfs.tech" or "k51qzi5uqu5dip7dqovvkldk0lz03wjkc2cndoskxpyh742gvcd5fw4mudsorj".</param>
+    /// <param name="name">A custom name to use for the file.</param>
+    /// <param name="client">The IPFS Client to use for retrieving the content.</param>
+    public IpnsFile(string ipnsAddress, string name, ICoreApi client)
+    {
+        Id = ipnsAddress;
+        Name = name;
         Client = client;
     }
 

--- a/src/Key.cs
+++ b/src/Key.cs
@@ -1,0 +1,42 @@
+using Ipfs;
+using Newtonsoft.Json;
+
+namespace OwlCore.Kubo;
+
+/// <summary>
+/// This record is a simple implementation of the <see cref="IKey"/> interface, representing a cryptographic key with an identifier and a name.
+/// </summary>
+/// <remarks>
+/// This is provided primarily for serialization purposes, as the <see cref="IKey"/> interface is an inbox interface and cannot be serialized directly.
+/// It is used to create a concrete type that can be serialized and deserialized while still adhering to the <see cref="IKey"/> contract.
+/// </remarks>
+public record Key : IKey
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="Key"/> class with the specified id and name.
+    /// </summary>
+    /// <param name="id">The Cid of the key.</param>
+    /// <param name="name">The name of the key.</param>
+    [JsonConstructor]
+    public Key(Cid id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="Key"/> class from an existing key.
+    /// </summary>
+    /// <param name="key">The key to copy the name and id from.</param>
+    public Key(IKey key)
+    {
+        Id = key.Id;
+        Name = key.Name;
+    }
+
+    /// <inheritdoc />
+    public Cid Id { get; set; }
+
+    /// <inheritdoc />
+    public string Name { get; set; }
+}

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -14,13 +14,35 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.20.2</Version>
+    <Version>0.21.0</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
+--- 0.21.0 ---
+[Fixes]
+Fixed an issue where ContentAddressedSystemFile wouldn't dispose of the FileStream if an exception is hit while adding to ipfs.
+
+[New]
+Added OwlCore.Kubo.Key, a simple implementation of IKey provided primarily for serialization purposes.
+The public static PathHelpers now has all-public members, complete with xml documentation.
+PathHelpers.IpfsProtocolPathValues was added.
+PathHelpers.IpnsProtocolPathValues was added.
+PathHelpers.MfsProtocolPathValues was added.
+PathHelpers.TryGetFileNameFromPathQuery was added. This method extracts the filename parameter from the query on a given path, if it exists.
+PathHelpers.RemoveProtocols was added. This method removes the given protocols from a path, returning only the path itself.
+PathHelpers.RemoveQueries was added. This simply removes all text after the given query separator, which is '?' by default.
+IpnsFile now has a constructor that takes a custom name.
+
+[Improvements]
+ContentAddressedSystemFile now passes FileOptions.SequentialScan to read the underlying file stream.
+PathHelpers.GetFolderItemName is now public. This method gets the name of the last item in a folder path, regardless of whether it's a file or a folder.
+PathHelpers.GetParentPath is now public. This method gets the parent of the item at the given path (file or folder), or "/" if the path is the root.
+PathHelpers.GetParentDirectoryName is now public. This method parses the given relative path and returns only the name of the parent directory, or null if the path is the root.
+The existing IpnsFile(string ipnsAddress, ICoreApi ipfsClient) constructor now automatically extracts the filename query from the path parameters, if they exist. This exists to support when the root CID published to IPNS is a file and not a folder.
+
 --- 0.20.2 ---
 [Fixes]
 Fix file stream disposal in ContentAddressedSystemFile.GetCidAsync.

--- a/src/PathHelpers.cs
+++ b/src/PathHelpers.cs
@@ -1,17 +1,115 @@
-﻿namespace OwlCore.Kubo;
+﻿using Ipfs;
+
+namespace OwlCore.Kubo;
 
 /// <summary>
 /// A collection of helpers for working with paths.
 /// </summary>
 public static class PathHelpers
 {
-    internal static string GetFolderItemName(string path)
+    /// <summary>
+    /// The IPFS protocol path values, used to identify paths that are part of the IPFS network.
+    /// These paths typically start with "ipfs://" or "/ipfs/".
+    /// </summary>
+    public static string[] IpfsProtocolPathValues { get; } = ["ipfs://", "/ipfs/"];
+
+    /// <summary>
+    /// The IPNS protocol path values, used to identify paths that are part of the IPNS (InterPlanetary Name System).
+    /// These paths typically start with "ipns://" or "/ipns/".
+    /// </summary>
+    public static string[] IpnsProtocolPathValues { get; } = ["ipns://", "/ipns/"];
+
+    /// <summary>
+    /// The MFS protocol path values, used to identify paths that are part of the MFS (Mutable File System).
+    /// These paths typically start with "mfs://" or "/mfs/".
+    /// </summary>
+    public static string[] MfsProtocolPathValues { get; } = ["mfs://", "/mfs/"];
+
+    /// <summary>
+    /// Tries to extract the file name from a path query, such as "ipfs://bafkreiemhhtwjmqpc735bpoa4rtahoowrmtrcn3jcy33jhdp7hvpqe2kx4?filename=MyFile".
+    /// </summary>
+    /// <param name="path">The path to extract the file name from.</param>
+    /// <returns>The extracted file name, or null if not found.</returns>
+    public static string? TryGetFileNameFromPathQuery(string path)
+    {
+        // Manually parse out the path query to get the file name
+        // Handle with or without trailing slash before the query
+        // Example: ipfs://bafkreiemhhtwjmqpc735bpoa4rtahoowrmtrcn3jcy33jhdp7hvpqe2kx4?filename=ManagedKeys
+#if NET5_0_OR_GREATER
+        var pathSplit = path.Split("filename=");
+#else
+        var pathSplit = path.Split(new[] { "filename=" }, StringSplitOptions.None);
+#endif
+
+        if (pathSplit.Length > 1)
+        {
+            var pathSplitFileNameStart = pathSplit[1];
+            var fileNameEndSplit = pathSplitFileNameStart.Split('&');
+
+            // If there are additional query parameters, take the first part as the file name
+            if (fileNameEndSplit.Length > 0)
+                return fileNameEndSplit[0];
+            // No additional query parameters, return the file name directly
+            else
+                return pathSplitFileNameStart;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Removes the given protocols from a path, returning only the path itself.
+    /// </summary>
+    /// <param name="path">The path with a prepended protocol.</param>
+    /// <param name="protocolValues">The protocol values to remove.</param>
+    /// <returns>The provided path without a prepended protocol.</returns>
+    /// <exception cref="ArgumentException">The provided path has no ipns protocol.</exception>
+    public static string RemoveProtocols(string path, string[] protocolValues)
+    {
+        foreach (var protocol in protocolValues)
+        {
+            if (path.StartsWith(protocol))
+            {
+                // Remove the protocol prefix and return the path
+                return path[protocol.Length..];
+            }
+        }
+
+        throw new ArgumentException($"No given protocols '{string.Join(", ", protocolValues)}' were found in {path}");
+    }
+
+    /// <summary>
+    /// Removes all query parameters from a path, returning only the path itself.
+    /// </summary>
+    public static string RemoveQueries(string path, char querySeparator = '?')
+    {
+        // Remove all query parameters if they exist
+        var pathQuerySplit = path.Split(querySeparator);
+        if (pathQuerySplit.Length > 1)
+            return pathQuerySplit[0];
+
+        return path;
+    }
+
+    /// <summary>
+    /// Gets the name of the last item in a folder path, regardless of whether it's a file or a folder.
+    /// This is useful for extracting the name of a file or folder from a path.
+    /// </summary>
+    /// <param name="path">The path to extract the item name from.</param>
+    /// <returns>The name of the last item in the path.</returns>
+    public static string GetFolderItemName(string path)
     {
         var parts = path.Trim('/').Split('/').ToArray();
         return parts[^1];
     }
 
-    internal static string GetParentPath(string relativePath)
+    /// <summary>
+    /// Gets the parent path of a given relative path.
+    /// If the provided path is the root ("/"), it returns "/".
+    /// </summary>
+    /// <param name="relativePath">The relative path to get the parent of.</param>
+    /// <returns>The parent path of the given relative path.</returns>
+    public static string GetParentPath(string relativePath)
     {
         // If the provided path is the root.
         if (relativePath.Trim('/').Split('/').Count() == 1)
@@ -29,7 +127,12 @@ public static class PathHelpers
         return parentDirectoryName?.Replace('\\', '/') + (isFolder ? directorySeparatorChar : string.Empty) ?? string.Empty;
     }
 
-    internal static string GetParentDirectoryName(string relativePath)
+    /// <summary>
+    /// Gets the name of the parent directory of a given relative path.
+    /// If the provided path is the root ("/"), it returns "/".
+    /// <param name="relativePath">The relative path to get the parent directory name from.</param>
+    /// <returns>The name of the parent directory.</returns>
+    public static string GetParentDirectoryName(string relativePath)
     {
         // If the provided path is the root.
         if (Path.GetPathRoot(relativePath)?.Replace('\\', '/') == relativePath)


### PR DESCRIPTION
[Fixes]
Fixed an issue where ContentAddressedSystemFile wouldn't dispose of the FileStream if an exception is hit while adding to ipfs.

[New]
Added OwlCore.Kubo.Key, a simple implementation of IKey provided primarily for serialization purposes.
The public static PathHelpers now has all-public members, complete with xml documentation.
PathHelpers.IpfsProtocolPathValues was added.
PathHelpers.IpnsProtocolPathValues was added.
PathHelpers.MfsProtocolPathValues was added.
PathHelpers.TryGetFileNameFromPathQuery was added. This method extracts the filename parameter from the query on a given path, if it exists.
PathHelpers.RemoveProtocols was added. This method removes the given protocols from a path, returning only the path itself.
PathHelpers.RemoveQueries was added. This simply removes all text after the given query separator, which is '?' by default.
IpnsFile now has a constructor that takes a custom name.

[Improvements]
ContentAddressedSystemFile now passes FileOptions.SequentialScan to read the underlying file stream.
PathHelpers.GetFolderItemName is now public. This method gets the name of the last item in a folder path, regardless of whether it's a file or a folder.
PathHelpers.GetParentPath is now public. This method gets the parent of the item at the given path (file or folder), or "/" if the path is the root.
PathHelpers.GetParentDirectoryName is now public. This method parses the given relative path and returns only the name of the parent directory, or null if the path is the root.
The existing IpnsFile(string ipnsAddress, ICoreApi ipfsClient) constructor now automatically extracts the filename query from the path parameters, if they exist. This exists to support when the root CID published to IPNS is a file and not a folder.
