### PR TITLE
Fixed IpnsFolder returning `/ipns/` root when getting parent starting from subfolder

### DIFF
--- a/src/IpnsFolder.cs
+++ b/src/IpnsFolder.cs
@@ -23,7 +23,7 @@ public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGet
 
         Client = client;
         Id = ipnsAddress;
-        Name = ipnsAddress == "/" ? "Root" : PathHelpers.GetFolderItemName(ipnsAddress);
+        Name = PathHelpers.IpnsProtocolPathValues.Any(x => x == Id) ? "Root" : PathHelpers.GetFolderItemName(ipnsAddress);
     }
 
     /// <inheritdoc />
@@ -48,7 +48,9 @@ public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGet
         if (Parent is not null)
             return Task.FromResult<IFolder?>(Parent);
 
-        return Task.FromResult<IFolder?>(Id == "/" ? null : new IpnsFolder(PathHelpers.GetParentPath(Id), Client));
+        var parentId = PathHelpers.GetParentPath(Id);
+
+        return Task.FromResult<IFolder?>(PathHelpers.IpnsProtocolPathValues.Any(x => x == parentId) ? null : new IpnsFolder(parentId, Client));
     }
 
     /// <inheritdoc />

--- a/tests/OwlCore.Kubo.Tests/IpnsFolderTests.cs
+++ b/tests/OwlCore.Kubo.Tests/IpnsFolderTests.cs
@@ -7,9 +7,48 @@ namespace OwlCore.Kubo.Tests
     public class IpnsFolderTests
     {
         [TestMethod]
+        public void PathHelpers_GetParentPath_IpnsRoot()
+        {
+            var parent = PathHelpers.GetParentPath("/ipns/ipfs.tech");
+            Assert.AreEqual("/ipns", parent);
+        }
+
+        [TestMethod]
+        public async Task GetParent_FromItemInRoot_ReturnsRootThenNull()
+        {
+            // Arrange: an IPNS root folder (no trailing child path)
+            var start = new IpnsFolder("/ipns/ipfs.tech/api/", TestFixture.Client);
+
+            // Act
+            var root = (IChildFolder?)await start.GetParentAsync();
+            
+            // Assert: parent of "/ipns/<name>/<subfolder>/" should be "/ipns/<name>"
+            Assert.IsNotNull(root);
+
+            // Act
+            var shouldBeNull = await root.GetParentAsync();
+
+            // Assert: parent of "/ipns/<name>" should be null (no "/ipns" folder)
+            Assert.IsNull(shouldBeNull);
+        }
+
+        [TestMethod]
+        public async Task GetParent_OnIpnsRoot_ReturnsNull()
+        {
+            // Arrange: an IPNS root folder (no trailing child path)
+            var root = new IpnsFolder("/ipns/ipfs.tech/", TestFixture.Client);
+
+            // Act
+            var parent = await root.GetParentAsync();
+
+            // Assert: parent of "/ipns/<name>" should be null (no "/ipns" folder)
+            Assert.IsNull(parent);
+        }
+
+        [TestMethod]
         public async Task GetFilesAsync()
         {
-            var folder = new IpnsFolder("/ipns/ipfs.tech", TestFixture.Client);
+            var folder = new IpnsFolder("/ipns/ipfs.tech/", TestFixture.Client);
             var files = await folder.GetFilesAsync().ToListAsync();
 
             foreach (var item in files)


### PR DESCRIPTION


This PR tests and fixes an issue where accessing an `IpnsFolder` subfolder via constructor address then navigating to parent repeatedly would yield an invalid rootmost `/ipns/` instead of returning null. 

> Parent is only assigned when you have an instance created by another instance. So it skips to line 51 where the exception occurs in your stack trace. The pattern here for detecting the root is wrong, so it's trying to get the parent using the path helper.
> 
> The pattern for the root here is the one from MFS, this is a copy-paste issue leftover from the refactor in 0.21.0

Reported in the Windows App Community Discord [`#owlcore`](https://discord.com/channels/372137812037730304/1019645710750199848/1406832448465014884) channel by @yoshiask.