### PR TITLE
Fixed IpnsFolder returning `/ipns/` root when getting parent starting at subfolder

### DIFF
--- a/src/IpnsFolder.cs
+++ b/src/IpnsFolder.cs
@@ -23,7 +23,7 @@ public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGet
 
         Client = client;
         Id = ipnsAddress;
-        Name = PathHelpers.IpnsProtocolPathValues.Any(x => x == Id) ? "Root" : PathHelpers.GetFolderItemName(ipnsAddress);
+        Name = PathHelpers.GetFolderItemName(ipnsAddress);
     }
 
     /// <inheritdoc />
@@ -50,7 +50,7 @@ public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGet
 
         var parentId = PathHelpers.GetParentPath(Id);
 
-        return Task.FromResult<IFolder?>(PathHelpers.IpnsProtocolPathValues.Any(x => x == parentId) ? null : new IpnsFolder(parentId, Client));
+        return Task.FromResult<IFolder?>(PathHelpers.IpnsProtocolPathValues.Any(x => x.Contains(parentId)) ? null : new IpnsFolder(parentId, Client));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Follow up to https://github.com/Arlodotexe/OwlCore.Kubo/pull/20

Reported by @yoshiask in [`#owlcore`](https://discord.com/channels/372137812037730304/1019645710750199848/1406864354950905897):
> Erm, that [updating to 0.22.1] didn't seem to fix it...
> `PathHelpers.IpnsProtocolPathValues.Any(x => x == parentId)` return `false`, `parentId` is `/ipns`

This PR fixes the issue by using a `.Contains` check instead of strict equality. If the full item Id is a substring of an Ipns root, null will be returned. This does *not* include when the protocol path prefix is in the Id, only when the Id is found within the path prefix.