### PR TITLE
Fixed invalid filenames on downloaded Kubo binary when specific version is requested. 

### DIFF
--- a/src/Downloader/KuboDownloader.cs
+++ b/src/Downloader/KuboDownloader.cs
@@ -105,7 +105,7 @@ public static class KuboDownloader
         };
 
         // Returning the file allows the consumer to copy the Stream directly from the internet to a new location.
-        return new StreamFile(delegatedDisposableStream);
+        return new StreamFile(delegatedDisposableStream, id: found.BinaryFile.Id, name: found.BinaryFile.Name);
     }
 
     /// <summary>
@@ -154,7 +154,7 @@ public static class KuboDownloader
         };
 
         // Returning the file allows the consumer to copy the Stream directly from the internet to a new location.
-        return new StreamFile(delegatedDisposableStream);
+        return new StreamFile(delegatedDisposableStream, id: found.BinaryFile.Id, name: found.BinaryFile.Name);
     }
 
     /// <summary>
@@ -192,7 +192,7 @@ public static class KuboDownloader
         };
 
         // Returning the file allows the consumer to copy the Stream directly from the internet to a new location.
-        return new StreamFile(delegatedDisposableStream);
+        return new StreamFile(delegatedDisposableStream, id: found.BinaryFile.Id, name: found.BinaryFile.Name);
     }
 
     /// <summary>

--- a/tests/OwlCore.Kubo.Tests/KuboDownloaderTests.cs
+++ b/tests/OwlCore.Kubo.Tests/KuboDownloaderTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace OwlCore.Kubo.Tests
 {
     [TestClass]
@@ -21,6 +23,104 @@ namespace OwlCore.Kubo.Tests
         public async Task DownloadInvalidVersionAsync(string version)
         {
             await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(() => KuboDownloader.GetBinaryVersionAsync(Version.Parse(version)));
+        }
+
+        [TestMethod]
+        public async Task GetLatestBinaryAsync_FileNameIsIpfsOrKubo()
+        {
+            // Act
+            var binaryFile = await KuboDownloader.GetLatestBinaryAsync();
+
+            // Assert
+            Assert.IsNotNull(binaryFile);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(binaryFile.Name);
+            Assert.IsTrue(fileNameWithoutExtension == "ipfs" || fileNameWithoutExtension == "kubo", 
+                $"Expected file name without extension to be 'ipfs' or 'kubo', but got '{fileNameWithoutExtension}'");
+        }
+
+        [TestMethod]
+        [DataRow("0.17.0")]
+        public async Task GetBinaryVersionAsync_FileNameIsIpfsOrKubo(string versionString)
+        {
+            // Arrange
+            var version = Version.Parse(versionString);
+
+            // Act
+            var binaryFile = await KuboDownloader.GetBinaryVersionAsync(version);
+
+            // Assert
+            Assert.IsNotNull(binaryFile);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(binaryFile.Name);
+            Assert.IsTrue(fileNameWithoutExtension == "ipfs" || fileNameWithoutExtension == "kubo", 
+                $"Expected file name without extension to be 'ipfs' or 'kubo', but got '{fileNameWithoutExtension}' for version {versionString}");
+        }
+
+        [TestMethod]
+        public async Task GetLatestBinaryAsync_WithHttpClient_FileNameIsIpfsOrKubo()
+        {
+            // Arrange
+            using var httpClient = new HttpClient();
+
+            // Act
+            var binaryFile = await KuboDownloader.GetLatestBinaryAsync(httpClient);
+
+            // Assert
+            Assert.IsNotNull(binaryFile);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(binaryFile.Name);
+            Assert.IsTrue(fileNameWithoutExtension == "ipfs" || fileNameWithoutExtension == "kubo", 
+                $"Expected file name without extension to be 'ipfs' or 'kubo', but got '{fileNameWithoutExtension}'");
+        } 
+
+        [TestMethod]
+        [DataRow("0.16.0")]
+        public async Task GetBinaryVersionAsync_WithHttpClient_FileNameIsIpfsOrKubo(string versionString)
+        {
+            // Arrange
+            var version = Version.Parse(versionString);
+            using var httpClient = new HttpClient();
+
+            // Act
+            var binaryFile = await KuboDownloader.GetBinaryVersionAsync(httpClient, version);
+
+            // Assert
+            Assert.IsNotNull(binaryFile);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(binaryFile.Name);
+            Assert.IsTrue(fileNameWithoutExtension == "ipfs" || fileNameWithoutExtension == "kubo", 
+                $"Expected file name without extension to be 'ipfs' or 'kubo', but got '{fileNameWithoutExtension}' for version {versionString}");
+        }
+
+        [TestMethod]
+        public async Task GetLatestBinaryAsync_WithIpfsClient_FileNameIsIpfsOrKubo()
+        {
+            // Arrange
+            var ipfsClient = TestFixture.Client;
+
+            // Act
+            var binaryFile = await KuboDownloader.GetLatestBinaryAsync(ipfsClient);
+
+            // Assert
+            Assert.IsNotNull(binaryFile);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(binaryFile.Name);
+            Assert.IsTrue(fileNameWithoutExtension == "ipfs" || fileNameWithoutExtension == "kubo", 
+                $"Expected file name without extension to be 'ipfs' or 'kubo', but got '{fileNameWithoutExtension}'");
+        }
+
+        [TestMethod]
+        [DataRow("0.15.0")]
+        public async Task GetBinaryVersionAsync_WithIpfsClient_FileNameIsIpfsOrKubo(string versionString)
+        {
+            // Arrange
+            var version = Version.Parse(versionString);
+            var ipfsClient = TestFixture.Client;
+
+            // Act
+            var binaryFile = await KuboDownloader.GetBinaryVersionAsync(ipfsClient, version);
+
+            // Assert
+            Assert.IsNotNull(binaryFile);
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(binaryFile.Name);
+            Assert.IsTrue(fileNameWithoutExtension == "ipfs" || fileNameWithoutExtension == "kubo", 
+                $"Expected file name without extension to be 'ipfs' or 'kubo', but got '{fileNameWithoutExtension}' for version {versionString}");
         }
     }
 }


### PR DESCRIPTION
Fixed an issue where KuboDownloader would use random file names (based on StreamFile's GetHashCode) when specific versions were requested, rather than using the original filename which we expect to start with `ipfs` or `kubo`.