### PR TITLE
Release v0.22.4 - MfsStream.SetLength() fixes

### DIFF
--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -14,14 +14,23 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.22.3</Version>
+    <Version>0.22.4</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
--- 0.22.3 --
+--- 0.22.4 ---
+[Fixes]
+Fixed MfsStream.SetLength() not truncating files in IPFS when shrinking stream length. The method now correctly calls the IPFS MFS API with Truncate=true to update file size.
+Fixed MfsStream.SetLength() not clamping Position when new length is smaller than current position, violating Stream contract.
+Fixed MfsStream.SetLength() not throwing ObjectDisposedException on disposed streams.
+
+[Tests]
+Added 6 new tests covering SetLength truncation behavior and edge cases (position clamping, disposal, sparse files, deleted files).
+
+--- 0.22.3 ---
 [Fixes]
 Fixed an issue where KuboDownloader would use random file names (based on StreamFile's GetHashCode) when specific versions were requested, rather than using the original filename which we expect to start with ipfs or kubo.
 


### PR DESCRIPTION
# Version 0.22.4 Release

This release includes critical fixes to `MfsStream.SetLength()` and comprehensive test coverage improvements (#26)

## Fixes

### MfsStream.SetLength() Truncation Bug
Fixed `MfsStream.SetLength()` not truncating files in IPFS when shrinking stream length. The method now correctly calls the IPFS MFS API with `Truncate=true` to update file size, preventing data corruption when reducing stream length.

**Root cause**: The method only updated the internal `_length` field without calling the IPFS API to actually truncate the file.

**Solution**: Added `Mfs.WriteAsync()` call with `MfsWriteOptions.Truncate=true` when shrinking the stream.

### Stream Contract Violations
Fixed `MfsStream.SetLength()` not clamping `Position` when the new length is smaller than the current position, which violated the `Stream` base class contract.

Fixed `MfsStream.SetLength()` not throwing `ObjectDisposedException` on disposed streams, which violated proper lifecycle management.

## Test Coverage

Added 6 comprehensive tests for `SetLength()`:
- `SetLengthTruncates()` - Direct truncation via MfsStream
- `SetLengthTruncatesViaFileStream()` - Truncation via MfsFile.OpenStreamAsync() (matches real-world usage)
- `SetLengthOnUninitializedStream()` - IPFS sparse file handling
- `SetLengthWithPositionBeyondNewLength()` - Position clamping validation
- `SetLengthOnDeletedFile()` - IPFS file recreation behavior
- `SetLengthAfterDispose()` - Disposal lifecycle enforcement

All 50 tests in the suite now pass ✅

## Related PR

This version bump follows the merge of #[PR_NUMBER] which implemented the fixes.
