### PR TITLE
Release 0.23.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.x'
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.x'
 
     - name: Restore dependencies
       run: dotnet restore

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/IpfsFile.cs
+++ b/src/IpfsFile.cs
@@ -1,4 +1,4 @@
-﻿using Ipfs;
+using Ipfs;
 using Ipfs.CoreApi;
 using OwlCore.ComponentModel;
 using OwlCore.Storage;
@@ -8,8 +8,10 @@ namespace OwlCore.Kubo;
 /// <summary>
 /// A file that resides on IPFS.
 /// </summary>
-public class IpfsFile : IFile, IChildFile, IGetCid
+public class IpfsFile : IFile, IChildFile, IGetCid, ILastModifiedAt
 {
+    private IpfsLastModifiedAtProperty? _lastModifiedAt;
+
     /// <summary>
     /// Creates a new instance of <see cref="IpfsFile"/>.
     /// </summary>
@@ -57,6 +59,11 @@ public class IpfsFile : IFile, IChildFile, IGetCid
     /// <inheritdoc/>
     public virtual async Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (accessMode == 0)
+            throw new ArgumentOutOfRangeException(nameof(accessMode), accessMode, "FileAccess mode cannot be zero.");
+
         if (accessMode.HasFlag(FileAccess.Write))
             throw new NotSupportedException("Attempted to write data to an immutable file on IPFS.");
 
@@ -70,5 +77,8 @@ public class IpfsFile : IFile, IChildFile, IGetCid
 
     /// <inheritdoc/>
     public Task<Cid> GetCidAsync(CancellationToken cancellationToken) => Task.FromResult<Cid>(Id);
+
+    /// <inheritdoc/>
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new IpfsLastModifiedAtProperty(this, Client, Id);
 }
 

--- a/src/IpfsFolder.cs
+++ b/src/IpfsFolder.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
 using OwlCore.Storage;
@@ -9,8 +9,9 @@ namespace OwlCore.Kubo;
 /// <summary>
 /// A folder that resides on IPFS.
 /// </summary>
-public class IpfsFolder : IFolder, IChildFolder, IGetCid
+public class IpfsFolder : IFolder, IChildFolder, IGetCid, ILastModifiedAt
 {
+    private IpfsLastModifiedAtProperty? _lastModifiedAt;
 
     /// <summary>
     /// Creates a new instance of <see cref="IpfsFolder"/>.
@@ -60,6 +61,11 @@ public class IpfsFolder : IFolder, IChildFolder, IGetCid
     /// <inheritdoc/>
     public virtual async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (type == StorableType.None)
+            throw new ArgumentOutOfRangeException(nameof(type), type, "StorableType.None is not a valid value for GetItemsAsync.");
+
         var itemInfo = await Client.FileSystem.ListAsync(Id, cancellationToken);
         Guard.IsTrue(itemInfo.IsDirectory);
 
@@ -69,23 +75,32 @@ public class IpfsFolder : IFolder, IChildFolder, IGetCid
             Guard.IsNotNull(link.Name);
 
             var linkedItemInfo = await Client.Mfs.StatAsync($"/ipfs/{link.Id}", cancellationToken);
-            if (linkedItemInfo.IsDirectory && type.HasFlag(StorableType.Folder))
+            if (linkedItemInfo.IsDirectory)
             {
-                yield return new IpfsFolder(link.Id, link.Name, Client)
+                if (type.HasFlag(StorableType.Folder))
                 {
-                    Parent = this,
-                };
+                    yield return new IpfsFolder(link.Id, link.Name, Client)
+                    {
+                        Parent = this,
+                    };
+                }
             }
-            else if (type.HasFlag(StorableType.File))
+            else
             {
-                yield return new IpfsFile(link.Id, link.Name, Client)
+                if (type.HasFlag(StorableType.File))
                 {
-                    Parent = this,
-                };
+                    yield return new IpfsFile(link.Id, link.Name, Client)
+                    {
+                        Parent = this,
+                    };
+                }
             }
         }
     }
 
     /// <inheritdoc/>
     public Task<Cid> GetCidAsync(CancellationToken cancellationToken) => Task.FromResult<Cid>(Id);
+
+    /// <inheritdoc/>
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new IpfsLastModifiedAtProperty(this, Client, Id);
 }

--- a/src/IpnsFile.cs
+++ b/src/IpnsFile.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
 using OwlCore.Storage;
@@ -8,10 +8,12 @@ namespace OwlCore.Kubo;
 /// <summary>
 /// A file that resides on IPFS behind an IPNS Address.
 /// </summary>
-public class IpnsFile : IFile, IChildFile, IGetCid
+public class IpnsFile : IFile, IChildFile, IGetCid, ILastModifiedAt
 {
+    private IpnsLastModifiedAtProperty? _lastModifiedAt;
+
     /// <summary>
-    /// Creates a new instance of <see cref="IpnsFolder"/>.
+    /// Creates a new instance of <see cref="IpnsFile"/>.
     /// </summary>
     /// <param name="ipnsAddress">A resolvable IPNS address, such as "ipfs.tech" or "k51qzi5uqu5dip7dqovvkldk0lz03wjkc2cndoskxpyh742gvcd5fw4mudsorj".</param>
     /// <param name="client">The IPFS Client to use for retrieving the content.</param>
@@ -80,4 +82,7 @@ public class IpnsFile : IFile, IChildFile, IGetCid
         Guard.IsNotNull(cidOfResolvedIpfsPath.Hash);
         return cidOfResolvedIpfsPath.Hash;
     }
+
+    /// <inheritdoc/>
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new IpnsLastModifiedAtProperty(this, Client, Id);
 }

--- a/src/IpnsFolder.cs
+++ b/src/IpnsFolder.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
 using OwlCore.Kubo.FolderWatchers;
@@ -10,8 +10,10 @@ namespace OwlCore.Kubo;
 /// <summary>
 /// A folder that resides on IPFS behind an IPNS Address.
 /// </summary>
-public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGetItemRecursive, IGetCid
+public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGetItemRecursive, IGetCid, ILastModifiedAt
 {
+    private IpnsLastModifiedAtProperty? _lastModifiedAt;
+
     /// <summary>
     /// Creates a new instance of <see cref="IpnsFolder"/>.
     /// </summary>
@@ -135,4 +137,7 @@ public class IpnsFolder : IMutableFolder, IChildFolder, IGetRoot, IGetItem, IGet
         Guard.IsNotNull(cidOfResolvedPath.Hash);
         return cidOfResolvedPath.Hash;
     }
+
+    /// <inheritdoc/>
+    public ILastModifiedAtProperty LastModifiedAt => _lastModifiedAt ??= new IpnsLastModifiedAtProperty(this, Client, Id);
 }

--- a/src/MfsFile.cs
+++ b/src/MfsFile.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
 using OwlCore.Storage;
@@ -8,7 +8,7 @@ namespace OwlCore.Kubo;
 /// <summary>
 /// An file that resides in Kubo's Mutable Filesystem.
 /// </summary>
-public class MfsFile : IFile, IChildFile, IGetCid
+public class MfsFile : IFile, IChildFile, IGetCid, ILastModifiedAt
 {
     /// <summary>
     /// Creates a new instance of <see cref="MfsFile"/>.
@@ -54,6 +54,11 @@ public class MfsFile : IFile, IChildFile, IGetCid
     /// <inheritdoc/>
     public async Task<Stream> OpenStreamAsync(FileAccess accessMode = FileAccess.Read, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (accessMode == 0)
+            throw new ArgumentOutOfRangeException(nameof(accessMode), accessMode, "FileAccess mode cannot be zero.");
+
         var data = await Client.Mfs.StatAsync(Path, cancellationToken);
 
         Guard.IsNotNull(data);
@@ -77,4 +82,8 @@ public class MfsFile : IFile, IChildFile, IGetCid
 
     /// <inheritdoc/>
     public Task<Cid> GetCidAsync(CancellationToken cancellationToken) => FlushAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public ILastModifiedAtProperty LastModifiedAt => new MfsLastModifiedAtProperty(this, Client, Path);
 }
+

--- a/src/MfsFolder.cs
+++ b/src/MfsFolder.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
 using Ipfs.Http;
@@ -13,7 +13,7 @@ namespace OwlCore.Kubo;
 /// <summary>
 /// A folder that resides in Kubo's Mutable Filesystem.
 /// </summary>
-public partial class MfsFolder : IFolder, IChildFolder, IGetItem, IGetItemRecursive, IGetFirstByName, IGetRoot, IGetCid
+public partial class MfsFolder : IFolder, IChildFolder, IGetItem, IGetItemRecursive, IGetFirstByName, IGetRoot, IGetCid, ILastModifiedAt
 {
     /// <summary>
     /// Creates a new instance of <see cref="MfsFolder"/>.
@@ -53,6 +53,11 @@ public partial class MfsFolder : IFolder, IChildFolder, IGetItem, IGetItemRecurs
     /// <inheritdoc/>
     public virtual async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (type == StorableType.None)
+            throw new ArgumentOutOfRangeException(nameof(type), type, "StorableType.None is not a valid value for GetItemsAsync.");
+
         var result = await Client.Mfs.ListAsync(Path, cancel: cancellationToken);
 
         foreach (var link in result ?? Enumerable.Empty<FileSystemNode>())
@@ -133,4 +138,7 @@ public partial class MfsFolder : IFolder, IChildFolder, IGetItem, IGetItemRecurs
 
     /// <inheritdoc/>
     public Task<Cid> GetCidAsync(CancellationToken cancellationToken) => FlushAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public ILastModifiedAtProperty LastModifiedAt => new MfsLastModifiedAtProperty(this, Client, Path);
 }

--- a/src/MfsStream.cs
+++ b/src/MfsStream.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Common;
+using CommunityToolkit.Common;
 using CommunityToolkit.Diagnostics;
 using Ipfs.CoreApi;
 using System.Text;
@@ -87,6 +87,21 @@ public class MfsStream : Stream
 
         return bytes.Length;
     }
+
+#if !NETSTANDARD2_0
+    /// <inheritdoc/>
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        var result = await Client.Mfs.ReadFileStreamAsync(Path, offset: Position, count: buffer.Length, cancellationToken);
+        var bytes = await result.ToBytesAsync(cancellationToken);
+
+        bytes.CopyTo(buffer);
+
+        Position += bytes.Length;
+
+        return bytes.Length;
+    }
+#endif
 
     /// <inheritdoc/>
     public override long Seek(long offset, SeekOrigin origin)

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
@@ -14,13 +14,28 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.22.4</Version>
+    <Version>0.23.0</Version>
     <Product>OwlCore</Product>
     <Description>
       An essential toolkit for Kubo, IPFS and the distributed web. 
     </Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReleaseNotes>
+--- 0.23.0 ---
+[New]
+IpfsFile, IpfsFolder, IpnsFile, IpnsFolder, MfsFile and MfsFolder now implement ILastModifiedAt via the new IpfsLastModifiedAtProperty, IpnsLastModifiedAtProperty and MfsLastModifiedAtProperty.
+
+[Improvements]
+Added MfsStream.ReadAsync(Memory&lt;byte&gt;, CancellationToken) overload for net8.0 and above.
+Added argument validation in OpenStreamAsync — throws ArgumentOutOfRangeException when FileAccess is zero.
+Added argument validation in GetItemsAsync — throws ArgumentOutOfRangeException when StorableType.None is passed.
+Added cancellation checks on entry for all async methods.
+Updated dependencies to latest versions. Added net10.0 to supported TargetFrameworks.
+
+[Tests]
+Added MfsFileTests.
+Expanded coverage in IpfsFileTests, IpfsFolderTests and MfsFolderTests.
+
 --- 0.22.4 ---
 [Fixes]
 Fixed MfsStream.SetLength() not truncating files in IPFS when shrinking stream length. The method now correctly calls the IPFS MFS API with Truncate=true to update file size.
@@ -550,23 +565,20 @@ Added unit tests.
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
-    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.7.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.10.0" />
-    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.1.1" />
+    <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.8.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.11.1" />
+    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.1.2" />
     <PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
-    <PackageReference Include="OwlCore.Extensions" Version="0.10.0" />
-    <PackageReference Include="OwlCore.Storage.SharpCompress" Version="0.1.2" />
+    <PackageReference Include="OwlCore.Extensions" Version="0.11.1" />
+    <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+    <PackageReference Include="OwlCore.Storage.SharpCompress" Version="0.2.0" />
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="6.0.3" />
-    <PackageReference Include="System.Text.Json" Version="9.0.8" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="OwlCore.Storage" Version="0.14.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -567,7 +567,7 @@ Added unit tests.
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.2" />
     <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.8.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
     <PackageReference Include="OwlCore.ComponentModel" Version="0.12.0" />
     <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.2.0" />
     <PackageReference Include="OwlCore.Diagnostics" Version="0.1.0" />

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -563,10 +563,10 @@ Added unit tests.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Common" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Common" Version="8.4.2" />
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.2" />
     <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.8.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
     <PackageReference Include="OwlCore.ComponentModel" Version="0.12.0" />
     <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.2.0" />
@@ -578,7 +578,7 @@ Added unit tests.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/src/OwlCore.Kubo.csproj
+++ b/src/OwlCore.Kubo.csproj
@@ -26,7 +26,7 @@
 IpfsFile, IpfsFolder, IpnsFile, IpnsFolder, MfsFile and MfsFolder now implement ILastModifiedAt via the new IpfsLastModifiedAtProperty, IpnsLastModifiedAtProperty and MfsLastModifiedAtProperty.
 
 [Improvements]
-Added MfsStream.ReadAsync(Memory&lt;byte&gt;, CancellationToken) overload for net8.0 and above.
+Added MfsStream.ReadAsync(Memory{byte}, CancellationToken) overload for net8.0 and above.
 Added argument validation in OpenStreamAsync — throws ArgumentOutOfRangeException when FileAccess is zero.
 Added argument validation in GetItemsAsync — throws ArgumentOutOfRangeException when StorableType.None is passed.
 Added cancellation checks on entry for all async methods.
@@ -568,9 +568,9 @@ Added unit tests.
     <PackageReference Include="IpfsShipyard.Ipfs.Http.Client" Version="0.8.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
-    <PackageReference Include="OwlCore.ComponentModel" Version="0.11.1" />
-    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.1.2" />
-    <PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
+    <PackageReference Include="OwlCore.ComponentModel" Version="0.12.0" />
+    <PackageReference Include="OwlCore.ComponentModel.Settings" Version="0.2.0" />
+    <PackageReference Include="OwlCore.Diagnostics" Version="0.1.0" />
     <PackageReference Include="OwlCore.Extensions" Version="0.11.1" />
     <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
     <PackageReference Include="OwlCore.Storage.SharpCompress" Version="0.2.0" />
@@ -578,7 +578,7 @@ Added unit tests.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
     <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Properties/IpfsLastModifiedAtProperty.cs
+++ b/src/Properties/IpfsLastModifiedAtProperty.cs
@@ -1,0 +1,51 @@
+using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.Storage;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Kubo;
+
+/// <summary>
+/// A read-only property for accessing the last modified time of an IPFS item.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This property retrieves the optional UnixFS 1.5 <c>mtime</c> field from the DAG node
+/// via <c>files/stat</c>. Since IPFS content is immutable, this property is read-only.
+/// </para>
+/// <para>
+/// Most IPFS content does not have <c>mtime</c> set (it's opt-in per the UnixFS spec),
+/// so <see cref="IStorageProperty{T}.GetValueAsync"/> will often return <c>null</c>.
+/// </para>
+/// </remarks>
+public class IpfsLastModifiedAtProperty : SimpleStorageProperty<DateTime?>, ILastModifiedAtProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="IpfsLastModifiedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The storage item that owns this property.</param>
+    /// <param name="client">The IPFS client.</param>
+    /// <param name="cid">The CID of the IPFS content.</param>
+    public IpfsLastModifiedAtProperty(IStorable owner, ICoreApi client, Cid cid)
+        : base(
+            id: owner.Id + ":Mtime",
+            name: nameof(ILastModifiedAt.LastModifiedAt),
+            asyncGetter: async (ct) =>
+            {
+                // Use files/stat on the /ipfs/ path to decode the UnixFS Data blob
+                var stat = await client.Mfs.StatAsync($"/ipfs/{cid}", ct);
+                if (stat.Mtime == null)
+                    return null;
+
+                var dt = DateTimeOffset.FromUnixTimeSeconds(stat.Mtime.Value);
+                if (stat.MtimeNsecs.HasValue)
+                    dt = dt.AddTicks(stat.MtimeNsecs.Value / 100);
+
+                return dt.UtcDateTime;
+            })
+    {
+    }
+}
+

--- a/src/Properties/IpnsLastModifiedAtProperty.cs
+++ b/src/Properties/IpnsLastModifiedAtProperty.cs
@@ -1,0 +1,55 @@
+using Ipfs.CoreApi;
+using OwlCore.Storage;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.Kubo;
+
+/// <summary>
+/// A read-only property for accessing the last modified time of an IPNS item.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This property resolves the IPNS address to a CID, then retrieves the optional UnixFS 1.5 
+/// <c>mtime</c> field from the underlying DAG node via <c>files/stat</c>.
+/// Since IPNS points to immutable IPFS content, this property is read-only.
+/// </para>
+/// <para>
+/// Most IPFS content does not have <c>mtime</c> set (it's opt-in per the UnixFS spec),
+/// so <see cref="IStorageProperty{T}.GetValueAsync"/> will often return <c>null</c>.
+/// </para>
+/// </remarks>
+public class IpnsLastModifiedAtProperty : SimpleStorageProperty<DateTime?>, ILastModifiedAtProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="IpnsLastModifiedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The storage item that owns this property.</param>
+    /// <param name="client">The IPFS client.</param>
+    /// <param name="ipnsAddress">The IPNS address to resolve.</param>
+    public IpnsLastModifiedAtProperty(IStorable owner, ICoreApi client, string ipnsAddress)
+        : base(
+            id: owner.Id + ":Mtime",
+            name: nameof(ILastModifiedAt.LastModifiedAt),
+            asyncGetter: async (ct) =>
+            {
+                // Resolve IPNS to get the current CID
+                var resolvedIpns = await client.Name.ResolveAsync(ipnsAddress, recursive: true, cancel: ct);
+                
+                // Use files/stat on the resolved path to decode the UnixFS Data blob
+                var stat = await client.Mfs.StatAsync(resolvedIpns, ct);
+                
+                if (stat.Mtime == null)
+                    return null;
+
+                var dt = DateTimeOffset.FromUnixTimeSeconds(stat.Mtime.Value);
+                if (stat.MtimeNsecs.HasValue)
+                    dt = dt.AddTicks(stat.MtimeNsecs.Value / 100);
+
+                return dt.UtcDateTime;
+            })
+    {
+    }
+}
+

--- a/src/Properties/MfsLastModifiedAtProperty.cs
+++ b/src/Properties/MfsLastModifiedAtProperty.cs
@@ -1,0 +1,43 @@
+using Ipfs.CoreApi;
+using OwlCore.Storage;
+using System;
+using System.Threading.Tasks;
+
+namespace OwlCore.Kubo;
+
+/// <summary>
+/// A property for accessing and modifying the last modified time of an MFS item.
+/// </summary>
+public class MfsLastModifiedAtProperty : SimpleModifiableStorageProperty<DateTime?>, IModifiableLastModifiedAtProperty
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="MfsLastModifiedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The owner of the property.</param>
+    /// <param name="client">The IPFS client.</param>
+    /// <param name="path">The MFS path.</param>
+    public MfsLastModifiedAtProperty(IStorable owner, ICoreApi client, string path) : base(
+        id: owner.Id + ":Mtime",
+        name: nameof(ILastModifiedAt.LastModifiedAt),
+        asyncGetter: async (ct) =>
+        {
+            var stat = await client.Mfs.StatAsync(path, ct);
+            if (stat.Mtime == null)
+                return null;
+
+            var dt = DateTimeOffset.FromUnixTimeSeconds(stat.Mtime.Value);
+            
+            if (stat.MtimeNsecs.HasValue)
+                dt = dt.AddTicks(stat.MtimeNsecs.Value / 100);
+
+            return dt.UtcDateTime;
+        },
+        asyncSetter: async (val, ct) =>
+        {
+            if (val == null) throw new ArgumentNullException(nameof(val), "Cannot set last modified time to null.");
+            await client.Mfs.TouchAsync(path, val, ct);
+        }
+    )
+    {
+    }
+}

--- a/tests/OwlCore.Kubo.Tests/IpfsFileTests.cs
+++ b/tests/OwlCore.Kubo.Tests/IpfsFileTests.cs
@@ -1,86 +1,166 @@
-﻿using CommunityToolkit.Diagnostics;
+using CommunityToolkit.Diagnostics;
 using Ipfs.CoreApi;
 using OwlCore.Storage;
+using OwlCore.Storage.CommonTests;
 using OwlCore.Storage.System.IO;
 using OwlCore.Storage.System.Net.Http;
 
-namespace OwlCore.Kubo.Tests
+namespace OwlCore.Kubo.Tests;
+
+[TestClass]
+public class IpfsFileTests : CommonIFileTests
 {
-    [TestClass]
-    public class IpfsFileTests
+    private static int _testCounter;
+    private readonly List<string> _createdMfsPaths = new();
+
+    /// <inheritdoc/>
+    public override bool SupportsWriting => false;
+
+    /// <inheritdoc/>
+    /// <remarks>IPFS doesn't track created time.</remarks>
+    public override PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    /// <remarks>IPFS doesn't track last accessed time.</remarks>
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    /// <remarks>IPFS supports mtime via UnixFS 1.5.</remarks>
+    public override PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    public override async Task<IFile> CreateFileAsync()
     {
-        [TestMethod]
-        public async Task BasicFileRead_RpcApi_Test()
+        var testId = Interlocked.Increment(ref _testCounter);
+        var mfsPath = $"/ipfs_test_file_{testId}_{Guid.NewGuid():N}.bin";
+
+        // Create file in MFS first with content
+        await TestFixture.Client.Mfs.WriteAsync(mfsPath, "test content for ipfs file", new MfsWriteOptions { Create = true });
+
+        // Flush to get the CID (don't touch - it corrupts the content)
+        var cid = await TestFixture.Client.Mfs.FlushAsync(mfsPath);
+
+        _createdMfsPaths.Add(mfsPath);
+
+        // Return IpfsFile pointing to the CID (immutable, read-only)
+        return new IpfsFile(cid, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFile?> CreateFileWithCreatedAtAsync(DateTime createdAt)
+    {
+        // IPFS doesn't support CreatedAt
+        return Task.FromResult<IFile?>(null);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IFile?> CreateFileWithLastModifiedAtAsync(DateTime lastModifiedAt)
+    {
+        var testId = Interlocked.Increment(ref _testCounter);
+        var mfsPath = $"/ipfs_test_file_{testId}_{Guid.NewGuid():N}.bin";
+
+        // Create file in MFS first with content
+        await TestFixture.Client.Mfs.WriteAsync(mfsPath, "test content for ipfs file", new MfsWriteOptions { Create = true });
+
+        // Set specific mtime
+        await TestFixture.Client.Mfs.TouchAsync(mfsPath, new DateTimeOffset(lastModifiedAt));
+
+        // Flush to get the CID
+        var cid = await TestFixture.Client.Mfs.FlushAsync(mfsPath);
+
+        _createdMfsPaths.Add(mfsPath);
+
+        return new IpfsFile(cid, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFile?> CreateFileWithLastAccessedAtAsync(DateTime lastAccessedAt)
+    {
+        // IPFS doesn't support LastAccessedAt
+        return Task.FromResult<IFile?>(null);
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        foreach (var path in _createdMfsPaths)
         {
-            var file = new IpfsFile("Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD", TestFixture.Client);
-            using var stream = await file.OpenStreamAsync();
-
-            using StreamReader text = new StreamReader(stream);
-            var txt = await text.ReadToEndAsync();
-
-            Assert.AreEqual("hello world", txt);
+            try { await TestFixture.Client.Mfs.RemoveAsync(path, force: true); } catch { }
         }
+        _createdMfsPaths.Clear();
+    }
 
-        [TestMethod]
-        public async Task BasicFileRead_Gateway_Test()
-        {
-            Guard.IsNotNull(TestFixture.Bootstrapper);
+    [TestMethod]
+    public async Task BasicFileRead_RpcApi_Test()
+    {
+        var file = new IpfsFile("Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD", TestFixture.Client);
+        using var stream = await file.OpenStreamAsync();
 
-            var file = new HttpFile($"{TestFixture.Bootstrapper.GatewayUri}/ipfs/Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD");
-            var txt = await file.ReadTextAsync();
+        using StreamReader text = new StreamReader(stream);
+        var txt = await text.ReadToEndAsync();
 
-            Assert.AreEqual("hello world", txt);
-        }
+        Assert.AreEqual("hello world", txt);
+    }
 
-        [TestMethod]
-        public async Task BasicFileRead_RpcApi_LargeFile_Test()
-        {
-            var bufferSize = 4096;
-            var totalFileSize = (long)int.MaxValue + 1024;
+    [TestMethod]
+    public async Task BasicFileRead_Gateway_Test()
+    {
+        Guard.IsNotNull(TestFixture.Bootstrapper);
 
-            // Generate a large file
-            var workingFile = new SystemFile(Path.GetTempFileName());
-            await workingFile.WriteRandomBytesAsync(totalFileSize, bufferSize, CancellationToken.None);
+        var file = new HttpFile($"{TestFixture.Bootstrapper.GatewayUri}/ipfs/Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD");
+        var txt = await file.ReadTextAsync();
 
-            // Upload large file via RPC API
-            using var srcFileStream = await workingFile.OpenReadAsync();
-            var added = await TestFixture.Client.FileSystem.AddAsync([new FilePart { AbsolutePath = workingFile.Path, Data = srcFileStream, Name = workingFile.Name }], []).FirstAsync();
-            srcFileStream.Position = 0;
+        Assert.AreEqual("hello world", txt);
+    }
 
-            // Test with IpfsFile.
-            var file = new IpfsFile(added.Id, TestFixture.Client);
-            using var destFileStream = await file.OpenStreamAsync();
+    [TestMethod]
+    public async Task BasicFileRead_RpcApi_LargeFile_Test()
+    {
+        var bufferSize = 4096;
+        var totalFileSize = (long)int.MaxValue + 1024;
 
-            Assert.AreEqual(srcFileStream.Length, totalFileSize);
-            Assert.AreEqual(destFileStream.Length, totalFileSize);
+        // Generate a large file
+        var workingFile = new SystemFile(Path.GetTempFileName());
+        await workingFile.WriteRandomBytesAsync(totalFileSize, bufferSize, CancellationToken.None);
 
-            await srcFileStream.AssertStreamEqualAsync(destFileStream, bufferSize, CancellationToken.None);
-        }
+        // Upload large file via RPC API
+        using var srcFileStream = await workingFile.OpenReadAsync();
+        var added = await TestFixture.Client.FileSystem.AddAsync([new FilePart { AbsolutePath = workingFile.Path, Data = srcFileStream, Name = workingFile.Name }], []).FirstAsync();
+        srcFileStream.Position = 0;
 
-        [TestMethod]
-        public async Task BasicFileRead_Gateway_LargeFile_Test()
-        {
-            Guard.IsNotNull(TestFixture.Bootstrapper);
-            var bufferSize = 4096;
-            var totalFileSize = (long)int.MaxValue + 1024;
-            
-            // Generate a large file
-            var sourceFile = new SystemFile(Path.GetTempFileName());
-            await sourceFile.WriteRandomBytesAsync(totalFileSize, bufferSize, CancellationToken.None);
+        // Test with IpfsFile.
+        var file = new IpfsFile(added.Id, TestFixture.Client);
+        using var destFileStream = await file.OpenStreamAsync();
 
-            // Upload large file via RPC API
-            var srcFileStream = await sourceFile.OpenReadAsync();
-            var added = await TestFixture.Client.FileSystem.AddAsync([new FilePart { AbsolutePath = sourceFile.Path, Data = srcFileStream, Name = sourceFile.Name }], []).FirstAsync();
-            srcFileStream.Position = 0;
+        Assert.AreEqual(srcFileStream.Length, totalFileSize);
+        Assert.AreEqual(destFileStream.Length, totalFileSize);
 
-            // Open large file via http gateway
-            var destFile = new HttpFile($"{TestFixture.Bootstrapper.GatewayUri}/ipfs/{added.Id}");
-            using var destFileStream = await destFile.OpenReadAsync();
+        await srcFileStream.AssertStreamEqualAsync(destFileStream, bufferSize, CancellationToken.None);
+    }
 
-            Assert.AreEqual(srcFileStream.Length, totalFileSize);
-            Assert.AreEqual(destFileStream.Length, totalFileSize);
+    [TestMethod]
+    public async Task BasicFileRead_Gateway_LargeFile_Test()
+    {
+        Guard.IsNotNull(TestFixture.Bootstrapper);
+        var bufferSize = 4096;
+        var totalFileSize = (long)int.MaxValue + 1024;
 
-            await srcFileStream.AssertStreamEqualAsync(destFileStream, bufferSize, CancellationToken.None);
-        }
+        // Generate a large file
+        var sourceFile = new SystemFile(Path.GetTempFileName());
+        await sourceFile.WriteRandomBytesAsync(totalFileSize, bufferSize, CancellationToken.None);
+
+        // Upload large file via RPC API
+        var srcFileStream = await sourceFile.OpenReadAsync();
+        var added = await TestFixture.Client.FileSystem.AddAsync([new FilePart { AbsolutePath = sourceFile.Path, Data = srcFileStream, Name = sourceFile.Name }], []).FirstAsync();
+        srcFileStream.Position = 0;
+
+        // Open large file via http gateway
+        var destFile = new HttpFile($"{TestFixture.Bootstrapper.GatewayUri}/ipfs/{added.Id}");
+        using var destFileStream = await destFile.OpenReadAsync();
+
+        Assert.AreEqual(srcFileStream.Length, totalFileSize);
+        Assert.AreEqual(destFileStream.Length, totalFileSize);
+
+        await srcFileStream.AssertStreamEqualAsync(destFileStream, bufferSize, CancellationToken.None);
     }
 }

--- a/tests/OwlCore.Kubo.Tests/IpfsFolderTests.cs
+++ b/tests/OwlCore.Kubo.Tests/IpfsFolderTests.cs
@@ -1,35 +1,135 @@
-﻿using OwlCore.Storage;
+using Ipfs.CoreApi;
+using OwlCore.Storage;
+using OwlCore.Storage.CommonTests;
 using System.Diagnostics;
 
-namespace OwlCore.Kubo.Tests
+namespace OwlCore.Kubo.Tests;
+
+[TestClass]
+public class IpfsFolderTests : CommonIFolderTests
 {
-    [TestClass]
-    public class IpfsFolderTests
+    private static int _testCounter;
+
+    /// <inheritdoc/>
+    /// <remarks>IPFS uses content-addressed CIDs which serve as both unique identifiers and valid names.</remarks>
+    public override bool AllowsIdEqualToName => true;
+
+    /// <inheritdoc/>
+    /// <remarks>IPFS supports mtime via UnixFS 1.5.</remarks>
+    public override PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Maybe;
+
+    private readonly List<string> _createdMfsPaths = new();
+
+    /// <inheritdoc/>
+    public override async Task<IFolder> CreateFolderAsync()
     {
-        [TestMethod]
-        public async Task GetFilesAsync()
+        var testId = Interlocked.Increment(ref _testCounter);
+        var mfsPath = $"/ipfs_test_folder_{testId}_{Guid.NewGuid():N}";
+
+        // Create folder in MFS with a child file
+        await TestFixture.Client.Mfs.MakeDirectoryAsync(mfsPath, parents: true);
+        await TestFixture.Client.Mfs.WriteAsync($"{mfsPath}/child.txt", "child content", new MfsWriteOptions { Create = true });
+
+        // Set mtime so LastModifiedAt tests can verify it
+        var mtime = DateTimeOffset.UtcNow;
+        await TestFixture.Client.Mfs.TouchAsync(mfsPath, mtime);
+
+        // Flush to get the CID
+        var cid = await TestFixture.Client.Mfs.FlushAsync(mfsPath);
+
+        _createdMfsPaths.Add(mfsPath);
+
+        return new IpfsFolder(cid, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IFolder> CreateFolderWithItems(int fileCount, int folderCount)
+    {
+        var testId = Interlocked.Increment(ref _testCounter);
+        var mfsPath = $"/ipfs_test_folder_items_{testId}_{Guid.NewGuid():N}";
+
+        await TestFixture.Client.Mfs.MakeDirectoryAsync(mfsPath, parents: true);
+
+        for (int i = 0; i < fileCount; i++)
+            await TestFixture.Client.Mfs.WriteAsync($"{mfsPath}/file_{i}.txt", $"content_{i}", new MfsWriteOptions { Create = true });
+
+        for (int i = 0; i < folderCount; i++)
+            await TestFixture.Client.Mfs.MakeDirectoryAsync($"{mfsPath}/folder_{i}", parents: true);
+
+        var mtime = DateTimeOffset.UtcNow;
+        await TestFixture.Client.Mfs.TouchAsync(mfsPath, mtime);
+
+        var cid = await TestFixture.Client.Mfs.FlushAsync(mfsPath);
+
+        _createdMfsPaths.Add(mfsPath);
+
+        return new IpfsFolder(cid, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFolder?> CreateFolderWithCreatedAtAsync(DateTime createdAt) =>
+        // IPFS doesn't support CreatedAt
+        Task.FromResult<IFolder?>(null);
+
+    /// <inheritdoc/>
+    public override async Task<IFolder?> CreateFolderWithLastModifiedAtAsync(DateTime lastModifiedAt)
+    {
+        var testId = Interlocked.Increment(ref _testCounter);
+        var mfsPath = $"/ipfs_test_folder_{testId}_{Guid.NewGuid():N}";
+
+        // Create folder in MFS with a child file
+        await TestFixture.Client.Mfs.MakeDirectoryAsync(mfsPath, parents: true);
+        await TestFixture.Client.Mfs.WriteAsync($"{mfsPath}/child.txt", "child content", new MfsWriteOptions { Create = true });
+
+        // Set specific mtime
+        await TestFixture.Client.Mfs.TouchAsync(mfsPath, new DateTimeOffset(lastModifiedAt));
+
+        // Flush to get the CID
+        var cid = await TestFixture.Client.Mfs.FlushAsync(mfsPath);
+
+        _createdMfsPaths.Add(mfsPath);
+
+        return new IpfsFolder(cid, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFolder?> CreateFolderWithLastAccessedAtAsync(DateTime lastAccessedAt) =>
+        // IPFS doesn't support LastAccessedAt
+        Task.FromResult<IFolder?>(null);
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        foreach (var path in _createdMfsPaths)
         {
-            var folder = new IpfsFolder("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D", TestFixture.Client);
-            var files = await folder.GetFilesAsync().ToListAsync();
-            
-            foreach(var item in files)
-                Debug.WriteLine($"{item.Name}, {item.Id}");
-
-            Assert.IsNotNull(files);
-            Assert.IsTrue(files.Count > 2);
+            try { await TestFixture.Client.Mfs.RemoveAsync(path, recursive: true, force: true); } catch { }
         }
+        _createdMfsPaths.Clear();
+    }
 
-        [TestMethod]
-        public async Task GetFoldersAsync()
-        {
-            var folder = new IpfsFolder("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D", TestFixture.Client);
-            var folders = await folder.GetFoldersAsync().ToListAsync();
-            
-            foreach(var item in folders)
-                Debug.WriteLine($"{item.Name}, {item.Id}");
+    [TestMethod]
+    public async Task GetFilesAsync()
+    {
+        var folder = new IpfsFolder("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D", TestFixture.Client);
+        var files = await folder.GetFilesAsync().ToListAsync();
 
-            Assert.IsNotNull(folders);
-            Assert.AreEqual(2, folders.Count);
-        }
+        foreach(var item in files)
+            Debug.WriteLine($"{item.Name}, {item.Id}");
+
+        Assert.IsNotNull(files);
+        Assert.IsTrue(files.Count > 2);
+    }
+
+    [TestMethod]
+    public async Task GetFoldersAsync()
+    {
+        var folder = new IpfsFolder("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D", TestFixture.Client);
+        var folders = await folder.GetFoldersAsync().ToListAsync();
+
+        foreach(var item in folders)
+            Debug.WriteLine($"{item.Name}, {item.Id}");
+
+        Assert.IsNotNull(folders);
+        Assert.AreEqual(2, folders.Count);
     }
 }

--- a/tests/OwlCore.Kubo.Tests/MfsFileTests.cs
+++ b/tests/OwlCore.Kubo.Tests/MfsFileTests.cs
@@ -1,0 +1,89 @@
+using Ipfs.CoreApi;
+using OwlCore.Storage;
+using OwlCore.Storage.CommonTests;
+
+namespace OwlCore.Kubo.Tests;
+
+[TestClass]
+public class MfsFileTests : CommonIFileTests
+{
+    private static int _testCounter;
+    private readonly List<string> _createdPaths = new();
+
+    /// <inheritdoc/>
+    public override bool SupportsWriting => true;
+
+    /// <inheritdoc/>
+    /// <remarks>MFS doesn't automatically track mtime - it must be explicitly set via touch.</remarks>
+    public override PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    /// <remarks>MFS doesn't track created time.</remarks>
+    public override PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    /// <remarks>MFS doesn't track last accessed time.</remarks>
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    public override async Task<IFile> CreateFileAsync()
+    {
+        var testId = Interlocked.Increment(ref _testCounter);
+        var fileName = $"mfs_test_file_{testId}_{Guid.NewGuid():N}.bin";
+
+        // Create file from MFS root folder
+        var rootFolder = new MfsFolder("/", TestFixture.Client);
+        var file = await rootFolder.CreateFileAsync(fileName, overwrite: true);
+
+        // Write content using MfsStream
+        using (var stream = await file.OpenWriteAsync())
+        {
+            var data = new byte[256];
+            Random.Shared.NextBytes(data);
+            await stream.WriteAsync(data, 0, 256);
+            // Dispose will flush
+        }
+
+        _createdPaths.Add($"/{fileName}");
+
+        return file;
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFile?> CreateFileWithCreatedAtAsync(DateTime createdAt)
+    {
+        // MFS doesn't support CreatedAt
+        return Task.FromResult<IFile?>(null);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IFile?> CreateFileWithLastModifiedAtAsync(DateTime lastModifiedAt)
+    {
+        var file = await CreateFileAsync();
+        
+        // Set mtime via touch
+        if (file is MfsFile mfsFile)
+        {
+            await TestFixture.Client.Mfs.TouchAsync(mfsFile.Path, new DateTimeOffset(lastModifiedAt));
+        }
+
+        return file;
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFile?> CreateFileWithLastAccessedAtAsync(DateTime lastAccessedAt)
+    {
+        // MFS doesn't support LastAccessedAt
+        return Task.FromResult<IFile?>(null);
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        foreach (var path in _createdPaths)
+        {
+            try { await TestFixture.Client.Mfs.RemoveAsync(path, force: true); } catch { }
+        }
+        _createdPaths.Clear();
+    }
+}

--- a/tests/OwlCore.Kubo.Tests/MfsFolderTests.cs
+++ b/tests/OwlCore.Kubo.Tests/MfsFolderTests.cs
@@ -1,137 +1,234 @@
-﻿using OwlCore.Kubo.FolderWatchers;
+using Ipfs.CoreApi;
+using OwlCore.Kubo.FolderWatchers;
 using OwlCore.Storage;
+using OwlCore.Storage.CommonTests;
 
-namespace OwlCore.Kubo.Tests
+namespace OwlCore.Kubo.Tests;
+
+[TestClass]
+public class MfsFolderTests : CommonIFolderTests
 {
-    [TestClass]
-    public class MfsFolderTests
+    private static int _testCounter;
+    private readonly List<string> _createdPaths = new();
+
+    /// <inheritdoc/>
+    /// <remarks>MFS doesn't track created time.</remarks>
+    public override PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    /// <remarks>MFS doesn't track last accessed time.</remarks>
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    /// <remarks>MFS supports mtime via UnixFS 1.5.</remarks>
+    public override PropertyValueAvailability LastModifiedAtAvailability => PropertyValueAvailability.Maybe;
+
+    /// <inheritdoc/>
+    public override async Task<IFolder> CreateFolderAsync()
     {
-        [TestMethod]
-        public async Task GetItemsAsync()
-        {
-            var mfs = new MfsFolder("/", TestFixture.Client);
+        var testId = Interlocked.Increment(ref _testCounter);
+        var path = $"/mfs_test_folder_{testId}_{Guid.NewGuid():N}";
 
-            await mfs.GetItemsAsync().ToListAsync();
+        await TestFixture.Client.Mfs.MakeDirectoryAsync(path, parents: true);
+        await TestFixture.Client.Mfs.WriteAsync($"{path}/child.txt", "child content", new MfsWriteOptions { Create = true });
+
+        // Set mtime so LastModifiedAt tests can verify it
+        var mtime = DateTimeOffset.UtcNow;
+        await TestFixture.Client.Mfs.TouchAsync(path, mtime);
+
+        _createdPaths.Add(path);
+
+        return new MfsFolder(path, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IFolder> CreateFolderWithItems(int fileCount, int folderCount)
+    {
+        var testId = Interlocked.Increment(ref _testCounter);
+        var path = $"/mfs_test_folder_items_{testId}_{Guid.NewGuid():N}";
+
+        await TestFixture.Client.Mfs.MakeDirectoryAsync(path, parents: true);
+
+        for (int i = 0; i < fileCount; i++)
+            await TestFixture.Client.Mfs.WriteAsync($"{path}/file_{i}.txt", $"content_{i}", new MfsWriteOptions { Create = true });
+
+        for (int i = 0; i < folderCount; i++)
+            await TestFixture.Client.Mfs.MakeDirectoryAsync($"{path}/folder_{i}", parents: true);
+
+        var mtime = DateTimeOffset.UtcNow;
+        await TestFixture.Client.Mfs.TouchAsync(path, mtime);
+
+        _createdPaths.Add(path);
+
+        return new MfsFolder(path, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFolder?> CreateFolderWithCreatedAtAsync(DateTime createdAt)
+    {
+        // MFS doesn't support CreatedAt
+        return Task.FromResult<IFolder?>(null);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IFolder?> CreateFolderWithLastModifiedAtAsync(DateTime lastModifiedAt)
+    {
+        var testId = Interlocked.Increment(ref _testCounter);
+        var path = $"/mfs_test_folder_{testId}_{Guid.NewGuid():N}";
+
+        await TestFixture.Client.Mfs.MakeDirectoryAsync(path, parents: true);
+        await TestFixture.Client.Mfs.WriteAsync($"{path}/child.txt", "child content", new MfsWriteOptions { Create = true });
+
+        // Set specific mtime
+        await TestFixture.Client.Mfs.TouchAsync(path, new DateTimeOffset(lastModifiedAt));
+
+        _createdPaths.Add(path);
+
+        return new MfsFolder(path, TestFixture.Client);
+    }
+
+    /// <inheritdoc/>
+    public override Task<IFolder?> CreateFolderWithLastAccessedAtAsync(DateTime lastAccessedAt)
+    {
+        // MFS doesn't support LastAccessedAt
+        return Task.FromResult<IFolder?>(null);
+    }
+
+    [TestCleanup]
+    public async Task Cleanup()
+    {
+        foreach (var path in _createdPaths)
+        {
+            try { await TestFixture.Client.Mfs.RemoveAsync(path, recursive: true, force: true); } catch { }
         }
+        _createdPaths.Clear();
+    }
 
-        [TestMethod]
-        public async Task CreateAndDeleteFolderAsync()
+    [TestMethod]
+    public async Task GetItemsAsync()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
+
+        await mfs.GetItemsAsync().ToListAsync();
+    }
+
+    [TestMethod]
+    public async Task CreateAndDeleteFolderAsync()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
+        var folder = await mfs.CreateFolderAsync("test", overwrite: true);
+
+        await mfs.DeleteAsync(folder);
+
+        await Assert.ThrowsExceptionAsync<FileNotFoundException>(async () => await mfs.GetItemAsync("/test"));
+    }
+
+    [TestMethod]
+    public async Task CreateAndDeleteFolderAsync_Overwrite()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
+        var folder = await mfs.CreateFolderAsync("test", overwrite: true);
+
+        await ((IModifiableFolder)folder).CreateFileAsync("random", overwrite: true);
+
+        var itemsCount = await GetItemsCount(folder);
+        Assert.AreEqual(1, itemsCount);
+
+        var overwrittenFolder = await mfs.CreateFolderAsync("test", overwrite: true);
+
+        var overwrittenFolderItemsCount = await GetItemsCount(overwrittenFolder);
+        Assert.AreEqual(0, overwrittenFolderItemsCount);
+
+        await mfs.DeleteAsync(overwrittenFolder);
+
+        await Assert.ThrowsExceptionAsync<FileNotFoundException>(async () => await mfs.GetItemAsync("/test"));
+
+        Task<int> GetItemsCount(IFolder folder) => folder.GetItemsAsync().CountAsync().AsTask();
+    }
+
+    [TestMethod]
+    public async Task CreateAndDeleteFileAsync()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
+        var file = await mfs.CreateFileAsync("test.bin");
+        await mfs.DeleteAsync(file);
+
+        var items = await mfs.GetItemsAsync(StorableType.File).ToListAsync();
+
+        await Assert.ThrowsExceptionAsync<FileNotFoundException>(async () => await mfs.GetItemAsync("/test.bin"));
+    }
+
+    [TestMethod]
+    public async Task CreateAndDeleteFileAsync_Overwrite()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
+        var file = await mfs.CreateFileAsync("test.bin", overwrite: true);
+
+        // Write random data
+        var buffer = GenerateRandomData(256);
+        using var stream = await file.OpenStreamAsync(FileAccess.ReadWrite);
+        await stream.WriteAsync(buffer);
+        Assert.AreEqual(buffer.Length, stream.Length);
+
+        // Recreate the file
+        var overwrittenFile = await mfs.CreateFileAsync("test.bin", overwrite: true);
+        using var overwrittenFileStream = await overwrittenFile.OpenStreamAsync(FileAccess.ReadWrite);
+        Assert.AreNotEqual(buffer.Length, overwrittenFileStream.Length);
+
+        await mfs.DeleteAsync(overwrittenFile);
+    }
+
+    [TestMethod]
+    public async Task GetParentAsync()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
+
+        var folder = await mfs.CreateFolderAsync("test", overwrite: true);
+
+        var parent = await folder.GetParentAsync();
+
+        Assert.AreEqual(mfs.Id, parent?.Id);
+
+        await mfs.DeleteAsync(folder);
+    }
+
+    [TestMethod]
+    public async Task GetPathFromRootAsync()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
+        var folder = (MfsFolder)await mfs.CreateFolderAsync("test", overwrite: true);
+        var subfolder = (MfsFolder)await folder.CreateFolderAsync("subfolder", overwrite: true);
+
+        try
         {
-            var mfs = new MfsFolder("/", TestFixture.Client);
-            var folder = await mfs.CreateFolderAsync("test", overwrite: true);
+            var root = await subfolder.GetRootAsync();
+            Assert.IsNotNull(root);
 
+            var path = await root.GetRelativePathToAsync(subfolder);
+            Assert.AreEqual(path, subfolder.Path);
+        }
+        finally
+        {
             await mfs.DeleteAsync(folder);
-
-            await Assert.ThrowsExceptionAsync<FileNotFoundException>(async () => await mfs.GetItemAsync("/test"));
         }
+    }
 
-        [TestMethod]
-        public async Task CreateAndDeleteFolderAsync_Overwrite()
-        {
-            var mfs = new MfsFolder("/", TestFixture.Client);
-            var folder = await mfs.CreateFolderAsync("test", overwrite: true);
+    [TestMethod]
+    public async Task CreateAndRunFolderWatcher()
+    {
+        var mfs = new MfsFolder("/", TestFixture.Client);
 
-            await ((IModifiableFolder)folder).CreateFileAsync("random", overwrite: true);
+        var watcher = await mfs.GetFolderWatcherAsync();
 
-            var itemsCount = await GetItemsCount(folder);
-            Assert.AreEqual(1, itemsCount);
+        await ((TimerBasedFolderWatcher)watcher).ExecuteAsync();
+    }
 
-            var overwrittenFolder = await mfs.CreateFolderAsync("test", overwrite: true);
+    static byte[] GenerateRandomData(int length)
+    {
+        var rand = new Random();
+        var b = new byte[length];
+        rand.NextBytes(b);
 
-            var overwrittenFolderItemsCount = await GetItemsCount(overwrittenFolder);
-            Assert.AreEqual(0, overwrittenFolderItemsCount);
-
-            await mfs.DeleteAsync(overwrittenFolder);
-
-            await Assert.ThrowsExceptionAsync<FileNotFoundException>(async () => await mfs.GetItemAsync("/test"));
-
-            Task<int> GetItemsCount(IFolder folder) => folder.GetItemsAsync().CountAsync().AsTask();
-        }
-
-        [TestMethod]
-        public async Task CreateAndDeleteFileAsync()
-        {
-            var mfs = new MfsFolder("/", TestFixture.Client);
-            var file = await mfs.CreateFileAsync("test.bin");
-            await mfs.DeleteAsync(file);
-
-            var items = await mfs.GetItemsAsync(StorableType.File).ToListAsync();
-
-            await Assert.ThrowsExceptionAsync<FileNotFoundException>(async () => await mfs.GetItemAsync("/test.bin"));
-        }
-
-        [TestMethod]
-        public async Task CreateAndDeleteFileAsync_Overwrite()
-        {
-            var mfs = new MfsFolder("/", TestFixture.Client);
-            var file = await mfs.CreateFileAsync("test.bin", overwrite: true);
-
-            // Write random data
-            var buffer = GenerateRandomData(256);
-            using var stream = await file.OpenStreamAsync(FileAccess.ReadWrite);
-            await stream.WriteAsync(buffer);
-            Assert.AreEqual(buffer.Length, stream.Length);
-
-            // Recreate the file
-            var overwrittenFile = await mfs.CreateFileAsync("test.bin", overwrite: true);
-            using var overwrittenFileStream = await overwrittenFile.OpenStreamAsync(FileAccess.ReadWrite);
-            Assert.AreNotEqual(buffer.Length, overwrittenFileStream.Length);
-
-            await mfs.DeleteAsync(overwrittenFile);
-        }
-
-        [TestMethod]
-        public async Task GetParentAsync()
-        {
-            var mfs = new MfsFolder("/", TestFixture.Client);
-
-            var folder = await mfs.CreateFolderAsync("test", overwrite: true);
-
-            var parent = await folder.GetParentAsync();
-
-            Assert.AreEqual(mfs.Id, parent?.Id);
-
-            await mfs.DeleteAsync(folder);
-        }
-
-        [TestMethod]
-        public async Task GetPathFromRootAsync()
-        {
-            var mfs = new MfsFolder("/", TestFixture.Client);
-            var folder = (MfsFolder)await mfs.CreateFolderAsync("test", overwrite: true);
-            var subfolder = (MfsFolder)await folder.CreateFolderAsync("subfolder", overwrite: true);
-
-            try
-            {
-                var root = await subfolder.GetRootAsync();
-                Assert.IsNotNull(root);
-
-                var path = await root.GetRelativePathToAsync(subfolder);
-                Assert.AreEqual(path, subfolder.Path);
-            }
-            finally
-            {
-                await mfs.DeleteAsync(folder);
-            }
-        }
-
-        [TestMethod]
-        public async Task CreateAndRunFolderWatcher()
-        {
-            var mfs = new MfsFolder("/", TestFixture.Client);
-
-            var watcher = await mfs.GetFolderWatcherAsync();
-
-            await ((TimerBasedFolderWatcher)watcher).ExecuteAsync();
-        }
-
-        static byte[] GenerateRandomData(int length)
-        {
-            var rand = new Random();
-            var b = new byte[length];
-            rand.NextBytes(b);
-
-            return b;
-        }
+        return b;
     }
 }

--- a/tests/OwlCore.Kubo.Tests/OwlCore.Kubo.Tests.csproj
+++ b/tests/OwlCore.Kubo.Tests/OwlCore.Kubo.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12.0</LangVersion>
@@ -10,14 +10,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OwlCore.Extensions" Version="0.10.0" />
+    <PackageReference Include="OwlCore.Extensions" Version="0.11.1" />
+    <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
     <PackageReference Include="PolySharp" Version="1.15.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -26,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OwlCore.Kubo.csproj" />
+    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.6.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
--- 0.23.0 ---
[New]
IpfsFile, IpfsFolder, IpnsFile, IpnsFolder, MfsFile and MfsFolder now implement ILastModifiedAt via the new IpfsLastModifiedAtProperty, IpnsLastModifiedAtProperty and MfsLastModifiedAtProperty.

[Dependencies]
Updated OwlCore.Storage to 0.15.0.
Updated OwlCore.Storage.SharpCompress to 0.2.0.
Updated Microsoft.SourceLink.GitHub to 10.0.301.
Updated System.Linq.Async to 7.0.1.
Updated Microsoft.Bcl.AsyncInterfaces to 10.0.3.
Updated System.Text.Json to 10.0.10.
Added net10.0 to supported TargetFrameworks.